### PR TITLE
feat: connect chat to backend and socket

### DIFF
--- a/mobile/app.config.js
+++ b/mobile/app.config.js
@@ -1,0 +1,10 @@
+import 'dotenv/config';
+
+export default ({ config }) => {
+  const apiUrl = process.env.EXPO_PUBLIC_API_BASE_URL || 'http://localhost:4000';
+  process.env.EXPO_PUBLIC_API_BASE_URL = apiUrl;
+  return {
+    ...config,
+    extra: { ...config.extra, apiUrl },
+  };
+};

--- a/mobile/app/(client)/chats/[id].tsx
+++ b/mobile/app/(client)/chats/[id].tsx
@@ -2,19 +2,17 @@ import { useEffect, useRef, useState } from "react";
 import { View, Text, FlatList, TextInput, Pressable, StyleSheet, KeyboardAvoidingView, Platform } from "react-native";
 import { useLocalSearchParams } from "expo-router";
 import { listMessages, sendMessage, getSocket } from "@src/lib/api";
-import { useAuth } from "@src/store/useAuth";
 
 export default function ClientChatThread() {
   const { id } = useLocalSearchParams<{ id: string }>();
   const chatId = Number(id);
-  const { token } = useAuth();
   const [items, setItems] = useState<any[]>([]);
   const [text, setText] = useState("");
   const listRef = useRef<FlatList>(null);
 
   useEffect(() => {
     let mounted = true;
-    listMessages(chatId, token || undefined).then((m) => { if (mounted) setItems(m); });
+    listMessages(chatId).then((m) => { if (mounted) setItems(m); });
     const s = getSocket();
     if (s) {
       s.emit("join", { chatId });
@@ -26,13 +24,13 @@ export default function ClientChatThread() {
       });
     }
     return () => { mounted = false; s?.off("message:new"); };
-  }, [chatId, token]);
+  }, [chatId]);
 
   const onSend = async () => {
     const body = text.trim();
     if (!body) return;
     setText("");
-    const msg = await sendMessage(chatId, body, token || undefined);
+    const msg = await sendMessage(chatId, body);
     setItems((prev) => [...prev, msg]);
     setTimeout(() => listRef.current?.scrollToEnd({ animated: true }), 50);
   };

--- a/mobile/app/(labourer)/chats/[id].tsx
+++ b/mobile/app/(labourer)/chats/[id].tsx
@@ -26,6 +26,7 @@ import {
   getApplicationForChat,
   type Message,
   type Chat,
+  getSocket,
 } from "@src/lib/api";
 import { useAuth } from "@src/store/useAuth";
 import { useNotifications } from "@src/store/useNotifications";
@@ -77,6 +78,23 @@ export default function LabourerChatDetail() {
   useEffect(() => {
     requestAnimationFrame(() => listRef.current?.scrollToEnd({ animated: true }));
   }, [messages.length]);
+
+  useEffect(() => {
+    const s = getSocket();
+    if (s) {
+      s.emit("join", { chatId });
+      const handler = (msg: Message) => {
+        if (msg.chat_id === chatId) {
+          setMessages((prev) => [...prev, msg]);
+          listRef.current?.scrollToEnd({ animated: true });
+        }
+      };
+      s.on("message:new", handler);
+      return () => {
+        s.off("message:new", handler);
+      };
+    }
+  }, [chatId]);
 
   const onSend = useCallback(async () => {
     const body = input.trim();

--- a/mobile/app/(manager)/chats/[id].tsx
+++ b/mobile/app/(manager)/chats/[id].tsx
@@ -27,6 +27,7 @@ import {
   setApplicationStatus,
   type Message,
   type Chat,
+  getSocket,
 } from "@src/lib/api";
 import { useAuth } from "@src/store/useAuth";
 import { useNotifications } from "@src/store/useNotifications";
@@ -79,6 +80,23 @@ export default function ManagerChatDetail() {
   useEffect(() => {
     requestAnimationFrame(() => listRef.current?.scrollToEnd({ animated: true }));
   }, [messages.length]);
+
+  useEffect(() => {
+    const s = getSocket();
+    if (s) {
+      s.emit("join", { chatId });
+      const handler = (msg: Message) => {
+        if (msg.chat_id === chatId) {
+          setMessages((prev) => [...prev, msg]);
+          listRef.current?.scrollToEnd({ animated: true });
+        }
+      };
+      s.on("message:new", handler);
+      return () => {
+        s.off("message:new", handler);
+      };
+    }
+  }, [chatId]);
 
   const onSend = useCallback(async () => {
     const body = input.trim();


### PR DESCRIPTION
## Summary
- use real API endpoints for chats and messages
- add Socket.IO client and join chat rooms for realtime updates
- expose API base URL via Expo config

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_689a68b92b08832087f53c2fbce1171a