### PR TITLE
Show chat avatars and unread indicators

### DIFF
--- a/mobile/app.config.js
+++ b/mobile/app.config.js
@@ -1,0 +1,10 @@
+import 'dotenv/config';
+
+export default ({ config }) => {
+  const apiUrl = process.env.EXPO_PUBLIC_API_BASE_URL || 'http://localhost:4000';
+  process.env.EXPO_PUBLIC_API_BASE_URL = apiUrl;
+  return {
+    ...config,
+    extra: { ...config.extra, apiUrl },
+  };
+};

--- a/mobile/app/(client)/chats/[id].tsx
+++ b/mobile/app/(client)/chats/[id].tsx
@@ -1,70 +1,174 @@
-import { useEffect, useRef, useState } from "react";
-import { View, Text, FlatList, TextInput, Pressable, StyleSheet, KeyboardAvoidingView, Platform } from "react-native";
+import { useEffect, useRef, useState, useCallback } from "react";
+import {
+  View,
+  Text,
+  FlatList,
+  TextInput,
+  Pressable,
+  StyleSheet,
+  KeyboardAvoidingView,
+  Platform,
+  Image,
+} from "react-native";
 import { useLocalSearchParams } from "expo-router";
-import { listMessages, sendMessage, getSocket } from "@src/lib/api";
+import { listMessages, sendMessage, getSocket, type Message } from "@src/lib/api";
 import { useAuth } from "@src/store/useAuth";
+import { useProfile } from "@src/store/useProfile";
+import { Ionicons } from "@expo/vector-icons";
 
 export default function ClientChatThread() {
   const { id } = useLocalSearchParams<{ id: string }>();
   const chatId = Number(id);
-  const { token } = useAuth();
-  const [items, setItems] = useState<any[]>([]);
+  const { user } = useAuth();
+  const myId = user?.id ?? 0;
+  const profiles = useProfile((s) => s.profiles);
+  const [items, setItems] = useState<Message[]>([]);
   const [text, setText] = useState("");
-  const listRef = useRef<FlatList>(null);
+  const listRef = useRef<FlatList<Message>>(null);
 
   useEffect(() => {
     let mounted = true;
-    listMessages(chatId, token || undefined).then((m) => { if (mounted) setItems(m); });
+    listMessages(chatId).then((m) => {
+      if (mounted) setItems(m);
+    });
     const s = getSocket();
     if (s) {
       s.emit("join", { chatId });
-      s.on("message:new", (msg) => {
+      const handler = (msg: Message) => {
         if (msg.chat_id === chatId) {
           setItems((prev) => [...prev, msg]);
           listRef.current?.scrollToEnd({ animated: true });
         }
-      });
+      };
+      s.on("message:new", handler);
+      return () => {
+        mounted = false;
+        s.off("message:new", handler);
+      };
     }
-    return () => { mounted = false; s?.off("message:new"); };
-  }, [chatId, token]);
+    return () => {
+      mounted = false;
+    };
+  }, [chatId]);
 
-  const onSend = async () => {
+  const onSend = useCallback(async () => {
     const body = text.trim();
     if (!body) return;
     setText("");
-    const msg = await sendMessage(chatId, body, token || undefined);
+    const msg = await sendMessage(chatId, body);
     setItems((prev) => [...prev, msg]);
     setTimeout(() => listRef.current?.scrollToEnd({ animated: true }), 50);
+  }, [chatId, text]);
+
+  const renderItem = ({ item }: { item: Message }) => {
+    const isMine = item.user_id === myId;
+    const avatarUri = profiles[item.user_id || 0]?.avatarUri;
+    const avatar = avatarUri ? (
+      <Image source={{ uri: avatarUri }} style={styles.avatar} />
+    ) : (
+      <View style={[styles.avatar, styles.silhouette]}>
+        <Ionicons name="person" size={18} color="#9CA3AF" />
+      </View>
+    );
+    return (
+      <View style={[styles.row, isMine ? styles.rowMine : styles.rowTheirs]}>
+        {!isMine && avatar}
+        <View style={[styles.bubble, isMine ? styles.bubbleMine : styles.bubbleTheirs]}>
+          <Text style={styles.body}>{item.body}</Text>
+          {item.created_at ? (
+            <Text style={[styles.meta, isMine ? styles.metaMine : styles.metaTheirs]}>
+              {new Date(item.created_at).toLocaleTimeString([], { hour: "2-digit", minute: "2-digit" })}
+            </Text>
+          ) : null}
+        </View>
+        {isMine && avatar}
+      </View>
+    );
   };
 
   return (
-    <KeyboardAvoidingView style={{ flex:1 }} behavior={Platform.OS === "ios" ? "padding" : undefined} keyboardVerticalOffset={84}>
+    <KeyboardAvoidingView
+      style={{ flex: 1 }}
+      behavior={Platform.OS === "ios" ? "padding" : undefined}
+      keyboardVerticalOffset={84}
+    >
       <FlatList
         ref={listRef}
         data={items}
         keyExtractor={(m) => String(m.id)}
-        renderItem={({ item }) => (
-          <View style={[styles.msg, { alignSelf: "stretch" }]}>
-            <Text style={styles.meta}>{item.username} • {new Date(item.created_at).toLocaleTimeString()}</Text>
-            <Text style={styles.body}>{item.body}</Text>
-          </View>
-        )}
-        contentContainerStyle={{ padding: 12, gap: 8 }}
+        renderItem={renderItem}
+        contentContainerStyle={{ padding: 12 }}
         onContentSizeChange={() => listRef.current?.scrollToEnd({ animated: true })}
       />
       <View style={styles.inputRow}>
-        <TextInput value={text} onChangeText={setText} placeholder="Type a message" style={styles.input} />
-        <Pressable onPress={onSend} style={styles.send}><Text style={{ color:"#fff", fontWeight:"700" }}>Send</Text></Pressable>
+        <TextInput
+          value={text}
+          onChangeText={setText}
+          placeholder="Type a message"
+          style={styles.input}
+        />
+        <Pressable onPress={onSend} style={styles.send}>
+          <Text style={{ color: "#fff", fontWeight: "700" }}>Send</Text>
+        </Pressable>
       </View>
     </KeyboardAvoidingView>
   );
 }
 
 const styles = StyleSheet.create({
-  msg:{ padding:10, borderRadius:10, backgroundColor:"#F3F4F6" },
-  meta:{ color:"#6B7280", fontSize:12, marginBottom:2 },
-  body:{ fontSize:16 },
-  inputRow:{ flexDirection:"row", padding:10, gap:8, borderTopWidth:1, borderColor:"#eee", backgroundColor:"#fff" },
-  input:{ flex:1, borderWidth:1, borderColor:"#e5e5e5", borderRadius:10, paddingHorizontal:12, paddingVertical:10, backgroundColor:"#fff" },
-  send:{ backgroundColor:"#1f6feb", paddingHorizontal:16, borderRadius:10, alignItems:"center", justifyContent:"center" }
+  row: {
+    width: "100%",
+    marginVertical: 4,
+    paddingHorizontal: 6,
+    flexDirection: "row",
+    alignItems: "flex-end",
+    gap: 6,
+  },
+  rowMine: { justifyContent: "flex-end" },
+  rowTheirs: { justifyContent: "flex-start" },
+  bubble: {
+    maxWidth: "80%",
+    paddingVertical: 8,
+    paddingHorizontal: 12,
+    borderRadius: 16,
+  },
+  bubbleMine: {
+    backgroundColor: "#1f6feb",
+    borderBottomRightRadius: 4,
+  },
+  bubbleTheirs: {
+    backgroundColor: "#F3F4F6",
+    borderBottomLeftRadius: 4,
+  },
+  body: { fontSize: 16 },
+  meta: { fontSize: 11, marginTop: 4 },
+  metaMine: { color: "rgba(255,255,255,0.8)", textAlign: "right" },
+  metaTheirs: { color: "#6B7280" },
+  avatar: { width: 32, height: 32, borderRadius: 16, backgroundColor: "#E5E7EB" },
+  silhouette: { alignItems: "center", justifyContent: "center" },
+  inputRow: {
+    flexDirection: "row",
+    padding: 10,
+    gap: 8,
+    borderTopWidth: 1,
+    borderColor: "#eee",
+    backgroundColor: "#fff",
+  },
+  input: {
+    flex: 1,
+    borderWidth: 1,
+    borderColor: "#e5e5e5",
+    borderRadius: 10,
+    paddingHorizontal: 12,
+    paddingVertical: 10,
+    backgroundColor: "#fff",
+  },
+  send: {
+    backgroundColor: "#1f6feb",
+    paddingHorizontal: 16,
+    borderRadius: 10,
+    alignItems: "center",
+    justifyContent: "center",
+  },
 });
+

--- a/mobile/app/(manager)/chats/[id].tsx
+++ b/mobile/app/(manager)/chats/[id].tsx
@@ -14,6 +14,7 @@ import {
   Animated,
   Dimensions,
   BackHandler,
+  Image,
 } from "react-native";
 import { Stack, router, useLocalSearchParams } from "expo-router";
 import { useFocusEffect } from "@react-navigation/native";
@@ -27,9 +28,13 @@ import {
   setApplicationStatus,
   type Message,
   type Chat,
+  getSocket,
 } from "@src/lib/api";
 import { useAuth } from "@src/store/useAuth";
 import { useNotifications } from "@src/store/useNotifications";
+import { useChatBadge } from "@src/store/useChatBadge";
+import { useProfile } from "@src/store/useProfile";
+import { Ionicons } from "@expo/vector-icons";
 
 const GO_BACK_TO = "/(manager)/chats";
 
@@ -37,7 +42,9 @@ export default function ManagerChatDetail() {
   const { id } = useLocalSearchParams<{ id: string }>();
   const chatId = Number(id);
   const { user } = useAuth();
+  const myId = user?.id ?? 0;
   const myName = user?.username ?? "You";
+  const profiles = useProfile((s) => s.profiles);
 
   const insets = useSafeAreaInsets();
 
@@ -59,6 +66,10 @@ export default function ManagerChatDetail() {
     setMessages(Array.isArray(data) ? data : []);
     setChat(meta);
     setAppStatus(app?.status ?? null);
+    if (data.length) {
+      const last = data[data.length - 1].created_at;
+      useChatBadge.getState().markChatSeen(chatId, last);
+    }
   }, [chatId]);
 
   useFocusEffect(
@@ -80,6 +91,24 @@ export default function ManagerChatDetail() {
     requestAnimationFrame(() => listRef.current?.scrollToEnd({ animated: true }));
   }, [messages.length]);
 
+  useEffect(() => {
+    const s = getSocket();
+    if (s) {
+      s.emit("join", { chatId });
+      const handler = (msg: Message) => {
+        if (msg.chat_id === chatId) {
+          setMessages((prev) => [...prev, msg]);
+          listRef.current?.scrollToEnd({ animated: true });
+          useChatBadge.getState().markChatSeen(chatId, msg.created_at);
+        }
+      };
+      s.on("message:new", handler);
+      return () => {
+        s.off("message:new", handler);
+      };
+    }
+  }, [chatId]);
+
   const onSend = useCallback(async () => {
     const body = input.trim();
     if (!body) return;
@@ -88,6 +117,7 @@ export default function ManagerChatDetail() {
     const optimistic: Message = {
       id: Date.now(),
       chat_id: chatId,
+      user_id: myId,
       username: myName,
       body,
       created_at: new Date().toISOString(),
@@ -196,7 +226,8 @@ export default function ManagerChatDetail() {
 
   const renderItem = ({ item }: { item: Message }) => {
     const isSystem = item.username === "system";
-    const isMine = !isSystem && item.username === myName;
+    const isMine = !isSystem && item.user_id === myId;
+    const avatarUri = profiles[item.user_id || 0]?.avatarUri;
 
     if (isSystem) {
       return (
@@ -206,8 +237,17 @@ export default function ManagerChatDetail() {
       );
     }
 
+    const avatar = avatarUri ? (
+      <Image source={{ uri: avatarUri }} style={styles.avatar} />
+    ) : (
+      <View style={[styles.avatar, styles.silhouette]}>
+        <Ionicons name="person" size={18} color="#9CA3AF" />
+      </View>
+    );
+
     return (
       <View style={[styles.row, isMine ? styles.rowMine : styles.rowTheirs]}>
+        {!isMine && avatar}
         <View style={[styles.bubble, isMine ? styles.bubbleMine : styles.bubbleTheirs]}>
           <Text style={[styles.text, isMine ? styles.textMine : styles.textTheirs]}>{item.body}</Text>
           {item.created_at ? (
@@ -216,6 +256,7 @@ export default function ManagerChatDetail() {
             </Text>
           ) : null}
         </View>
+        {isMine && avatar}
       </View>
     );
   };
@@ -377,7 +418,14 @@ const styles = StyleSheet.create({
   btnDeclineText: { color: "#fff", fontWeight: "700" },
   btnDisabled: { opacity: 0.6 },
 
-  row: { width: "100%", marginVertical: 4, paddingHorizontal: 6, flexDirection: "row" },
+  row: {
+    width: "100%",
+    marginVertical: 4,
+    paddingHorizontal: 6,
+    flexDirection: "row",
+    alignItems: "flex-end",
+    gap: 6,
+  },
   rowMine: { justifyContent: "flex-end" },
   rowTheirs: { justifyContent: "flex-start" },
 
@@ -406,6 +454,9 @@ const styles = StyleSheet.create({
 
   systemWrap: { width: "100%", alignItems: "center", marginVertical: 6 },
   systemText: { fontSize: 12, color: "#777" },
+
+  avatar: { width: 32, height: 32, borderRadius: 16, backgroundColor: "#E5E7EB" },
+  silhouette: { alignItems: "center", justifyContent: "center" },
 
   composerWrap: {
     position: "absolute",


### PR DESCRIPTION
## Summary
- include sender IDs in message data so chats can resolve participant avatars
- render each sender's profile image beside messages in chat threads

## Testing
- `cd server && npm test` (fails: Missing script "test")
- `cd server && npm run lint` (fails: Missing script "lint")
- `cd mobile && npm test` (fails: Missing script "test")
- `cd mobile && npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689a68b92b08832087f53c2fbce1171a