### PR TITLE
Show chat avatars and unread indicators

### DIFF
--- a/mobile/app/(client)/chats/[id].tsx
+++ b/mobile/app/(client)/chats/[id].tsx
@@ -12,6 +12,7 @@ import {
 } from "react-native";
 import { useLocalSearchParams } from "expo-router";
 import { listMessages, sendMessage, getSocket, type Message } from "@src/lib/api";
+import { parseDate } from "@src/lib/date";
 import { useAuth } from "@src/store/useAuth";
 import { useProfile } from "@src/store/useProfile";
 import { Ionicons } from "@expo/vector-icons";
@@ -60,9 +61,11 @@ export default function ClientChatThread() {
     setTimeout(() => listRef.current?.scrollToEnd({ animated: true }), 50);
   }, [chatId, text]);
 
-  const renderItem = ({ item }: { item: Message }) => {
+  const renderItem = ({ item, index }: { item: Message; index: number }) => {
     const isMine = item.user_id === myId;
     const avatarUri = profiles[item.user_id || 0]?.avatarUri;
+    const next = items[index + 1];
+    const showAvatar = !next || next.user_id !== item.user_id;
     const avatar = avatarUri ? (
       <Image source={{ uri: avatarUri }} style={styles.avatar} />
     ) : (
@@ -72,16 +75,16 @@ export default function ClientChatThread() {
     );
     return (
       <View style={[styles.row, isMine ? styles.rowMine : styles.rowTheirs]}>
-        {!isMine && avatar}
+        {!isMine && showAvatar && avatar}
         <View style={[styles.bubble, isMine ? styles.bubbleMine : styles.bubbleTheirs]}>
           <Text style={styles.body}>{item.body}</Text>
           {item.created_at ? (
             <Text style={[styles.meta, isMine ? styles.metaMine : styles.metaTheirs]}>
-              {new Date(item.created_at).toLocaleTimeString([], { hour: "2-digit", minute: "2-digit" })}
+              {parseDate(item.created_at).toLocaleTimeString([], { hour: "2-digit", minute: "2-digit" })}
             </Text>
           ) : null}
         </View>
-        {isMine && avatar}
+        {isMine && showAvatar && avatar}
       </View>
     );
   };

--- a/mobile/app/(labourer)/chats.tsx
+++ b/mobile/app/(labourer)/chats.tsx
@@ -2,6 +2,7 @@ import { useEffect, useState, useCallback } from "react";
 import { View, FlatList, Text, Pressable, StyleSheet, Image } from "react-native";
 import TopBar from "@src/components/TopBar";
 import { listChats, type Chat } from "@src/lib/api";
+import { parseDate } from "@src/lib/date";
 import { useAuth } from "@src/store/useAuth";
 import { useFocusEffect, router } from "expo-router";
 import { useNotifications } from "@src/store/useNotifications";
@@ -40,7 +41,7 @@ export default function Chats() {
     const avatarUri = otherId ? profiles[otherId]?.avatarUri : undefined;
     const seen = lastSeen[item.id];
     const isUnread = item.lastTime
-      ? !seen || new Date(seen) < new Date(item.lastTime)
+      ? !seen || parseDate(seen) < parseDate(item.lastTime)
       : false;
 
     return (

--- a/mobile/app/(labourer)/chats/[id].tsx
+++ b/mobile/app/(labourer)/chats/[id].tsx
@@ -34,6 +34,7 @@ import { useNotifications } from "@src/store/useNotifications";
 import { useChatBadge } from "@src/store/useChatBadge";
 import { useProfile } from "@src/store/useProfile";
 import { Ionicons } from "@expo/vector-icons";
+import { parseDate } from "@src/lib/date";
 
 const GO_BACK_TO = "/(labourer)/chats";
 
@@ -205,10 +206,12 @@ export default function LabourerChatDetail() {
     return other;
   }, [messages, myName, chat]);
 
-  const renderItem = ({ item }: { item: Message }) => {
+  const renderItem = ({ item, index }: { item: Message; index: number }) => {
     const isSystem = item.username === "system";
     const isMine = !isSystem && item.user_id === myId;
     const avatarUri = profiles[item.user_id || 0]?.avatarUri;
+    const next = messages[index + 1];
+    const showAvatar = !isSystem && (!next || next.user_id !== item.user_id);
 
     if (isSystem) {
       return (
@@ -228,16 +231,16 @@ export default function LabourerChatDetail() {
 
     return (
       <View style={[styles.row, isMine ? styles.rowMine : styles.rowTheirs]}>
-        {!isMine && avatar}
+        {!isMine && showAvatar && avatar}
         <View style={[styles.bubble, isMine ? styles.bubbleMine : styles.bubbleTheirs]}>
           <Text style={[styles.text, isMine ? styles.textMine : styles.textTheirs]}>{item.body}</Text>
           {item.created_at ? (
             <Text style={[styles.time, isMine ? styles.timeMine : styles.timeTheirs]}>
-              {new Date(item.created_at).toLocaleTimeString([], { hour: "2-digit", minute: "2-digit" })}
+              {parseDate(item.created_at).toLocaleTimeString([], { hour: "2-digit", minute: "2-digit" })}
             </Text>
           ) : null}
         </View>
-        {isMine && avatar}
+        {isMine && showAvatar && avatar}
       </View>
     );
   };

--- a/mobile/app/(manager)/chats.tsx
+++ b/mobile/app/(manager)/chats.tsx
@@ -2,6 +2,7 @@ import { useEffect, useState, useCallback } from "react";
 import { View, FlatList, Text, Pressable, StyleSheet, Image } from "react-native";
 import TopBar from "@src/components/TopBar";
 import { listChats, type Chat } from "@src/lib/api";
+import { parseDate } from "@src/lib/date";
 import { useAuth } from "@src/store/useAuth";
 import { useFocusEffect, router } from "expo-router";
 import { useNotifications } from "@src/store/useNotifications";
@@ -40,7 +41,7 @@ export default function Chats() {
     const avatarUri = otherId ? profiles[otherId]?.avatarUri : undefined;
     const seen = lastSeen[item.id];
     const isUnread = item.lastTime
-      ? !seen || new Date(seen) < new Date(item.lastTime)
+      ? !seen || parseDate(seen) < parseDate(item.lastTime)
       : false;
 
     return (

--- a/mobile/app/(manager)/chats/[id].tsx
+++ b/mobile/app/(manager)/chats/[id].tsx
@@ -20,16 +20,17 @@ import { Stack, router, useLocalSearchParams } from "expo-router";
 import { useFocusEffect } from "@react-navigation/native";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
 import { Colors } from "@src/theme/tokens";
-import {
-  listMessages,
-  sendMessage,
-  getChat,
-  getApplicationForChat,
-  setApplicationStatus,
-  type Message,
-  type Chat,
-  getSocket,
-} from "@src/lib/api";
+  import {
+    listMessages,
+    sendMessage,
+    getChat,
+    getApplicationForChat,
+    setApplicationStatus,
+    type Message,
+    type Chat,
+    getSocket,
+  } from "@src/lib/api";
+import { parseDate } from "@src/lib/date";
 import { useAuth } from "@src/store/useAuth";
 import { useNotifications } from "@src/store/useNotifications";
 import { useChatBadge } from "@src/store/useChatBadge";
@@ -224,10 +225,12 @@ export default function ManagerChatDetail() {
     return other;
   }, [messages, myName, chat]);
 
-  const renderItem = ({ item }: { item: Message }) => {
+  const renderItem = ({ item, index }: { item: Message; index: number }) => {
     const isSystem = item.username === "system";
     const isMine = !isSystem && item.user_id === myId;
     const avatarUri = profiles[item.user_id || 0]?.avatarUri;
+    const next = messages[index + 1];
+    const showAvatar = !isSystem && (!next || next.user_id !== item.user_id);
 
     if (isSystem) {
       return (
@@ -247,16 +250,16 @@ export default function ManagerChatDetail() {
 
     return (
       <View style={[styles.row, isMine ? styles.rowMine : styles.rowTheirs]}>
-        {!isMine && avatar}
+        {!isMine && showAvatar && avatar}
         <View style={[styles.bubble, isMine ? styles.bubbleMine : styles.bubbleTheirs]}>
           <Text style={[styles.text, isMine ? styles.textMine : styles.textTheirs]}>{item.body}</Text>
           {item.created_at ? (
             <Text style={[styles.time, isMine ? styles.timeMine : styles.timeTheirs]}>
-              {new Date(item.created_at).toLocaleTimeString([], { hour: "2-digit", minute: "2-digit" })}
+              {parseDate(item.created_at).toLocaleTimeString([], { hour: "2-digit", minute: "2-digit" })}
             </Text>
           ) : null}
         </View>
-        {isMine && avatar}
+        {isMine && showAvatar && avatar}
       </View>
     );
   };

--- a/mobile/src/lib/date.ts
+++ b/mobile/src/lib/date.ts
@@ -1,0 +1,4 @@
+export function parseDate(value: string): Date {
+  if (!value) return new Date(NaN);
+  return new Date(value.includes('T') ? value : value.replace(' ', 'T') + 'Z');
+}

--- a/mobile/src/store/useChatBadge.ts
+++ b/mobile/src/store/useChatBadge.ts
@@ -2,6 +2,7 @@ import { create } from "zustand";
 import { persist, createJSONStorage } from "zustand/middleware";
 import AsyncStorage from "@react-native-async-storage/async-storage";
 import type { Chat } from "@src/lib/api";
+import { parseDate } from "@src/lib/date";
 
 type State = {
   lastSeenByChat: Record<number, string>;
@@ -19,7 +20,7 @@ export const useChatBadge = create<State>()(
         set((s) => ({
           lastSeenByChat: {
             ...s.lastSeenByChat,
-            [chatId]: (iso ? new Date(iso) : new Date()).toISOString(),
+            [chatId]: (iso ? parseDate(iso) : new Date()).toISOString(),
           },
         })),
 
@@ -28,7 +29,7 @@ export const useChatBadge = create<State>()(
         set((s) => {
           const next = { ...s.lastSeenByChat };
           chats.forEach((c) => {
-            if (c.lastTime) next[c.id] = new Date(c.lastTime).toISOString();
+            if (c.lastTime) next[c.id] = parseDate(c.lastTime).toISOString();
           });
           return { lastSeenByChat: next };
         }),
@@ -40,7 +41,7 @@ export const useChatBadge = create<State>()(
         for (const c of chats) {
           if (!c.lastTime) continue;
           const seen = map[c.id];
-          if (!seen || new Date(seen) < new Date(c.lastTime)) count += 1;
+          if (!seen || parseDate(seen) < parseDate(c.lastTime)) count += 1;
         }
         return count;
       },


### PR DESCRIPTION
## Summary
- include sender IDs in message data so chats can resolve participant avatars
- render each sender's profile image beside messages in chat threads
- fix unread dot logic by normalizing timestamps and comparing message times

## Testing
- `cd server && npm test` (fails: Missing script "test")
- `cd server && npm run lint` (fails: Missing script "lint")
- `cd mobile && npm test` (fails: Missing script "test")
- `cd mobile && npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689a68b92b08832087f53c2fbce1171a