### PR TITLE
Show avatar only on user's latest chat message

### DIFF
--- a/mobile/app/(client)/chats/[id].tsx
+++ b/mobile/app/(client)/chats/[id].tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState, useCallback } from "react";
+import { useEffect, useRef, useState, useCallback, useMemo } from "react";
 import {
   View,
   Text,
@@ -61,11 +61,21 @@ export default function ClientChatThread() {
     setTimeout(() => listRef.current?.scrollToEnd({ animated: true }), 50);
   }, [chatId, text]);
 
-  const renderItem = ({ item, index }: { item: Message; index: number }) => {
+  const lastByUser = useMemo(() => {
+    const map: Record<number, number> = {};
+    for (let i = items.length - 1; i >= 0; i--) {
+      const m = items[i];
+      if (m.user_id != null && map[m.user_id] == null) {
+        map[m.user_id] = m.id;
+      }
+    }
+    return map;
+  }, [items]);
+
+  const renderItem = ({ item }: { item: Message }) => {
     const isMine = item.user_id === myId;
     const avatarUri = profiles[item.user_id || 0]?.avatarUri;
-    const next = items[index + 1];
-    const showAvatar = !next || next.user_id !== item.user_id;
+    const showAvatar = item.user_id != null && item.id === lastByUser[item.user_id];
     const avatar = avatarUri ? (
       <Image source={{ uri: avatarUri }} style={styles.avatar} />
     ) : (

--- a/mobile/app/(labourer)/chats/[id].tsx
+++ b/mobile/app/(labourer)/chats/[id].tsx
@@ -206,12 +206,22 @@ export default function LabourerChatDetail() {
     return other;
   }, [messages, myName, chat]);
 
-  const renderItem = ({ item, index }: { item: Message; index: number }) => {
+  const lastByUser = useMemo(() => {
+    const map: Record<number, number> = {};
+    for (let i = messages.length - 1; i >= 0; i--) {
+      const m = messages[i];
+      if (m.user_id != null && m.username !== "system" && map[m.user_id] == null) {
+        map[m.user_id] = m.id;
+      }
+    }
+    return map;
+  }, [messages]);
+
+  const renderItem = ({ item }: { item: Message }) => {
     const isSystem = item.username === "system";
     const isMine = !isSystem && item.user_id === myId;
     const avatarUri = profiles[item.user_id || 0]?.avatarUri;
-    const next = messages[index + 1];
-    const showAvatar = !isSystem && (!next || next.user_id !== item.user_id);
+    const showAvatar = !isSystem && item.id === lastByUser[item.user_id || 0];
 
     if (isSystem) {
       return (

--- a/mobile/app/(manager)/chats/[id].tsx
+++ b/mobile/app/(manager)/chats/[id].tsx
@@ -225,12 +225,22 @@ export default function ManagerChatDetail() {
     return other;
   }, [messages, myName, chat]);
 
-  const renderItem = ({ item, index }: { item: Message; index: number }) => {
+  const lastByUser = useMemo(() => {
+    const map: Record<number, number> = {};
+    for (let i = messages.length - 1; i >= 0; i--) {
+      const m = messages[i];
+      if (m.user_id != null && m.username !== "system" && map[m.user_id] == null) {
+        map[m.user_id] = m.id;
+      }
+    }
+    return map;
+  }, [messages]);
+
+  const renderItem = ({ item }: { item: Message }) => {
     const isSystem = item.username === "system";
     const isMine = !isSystem && item.user_id === myId;
     const avatarUri = profiles[item.user_id || 0]?.avatarUri;
-    const next = messages[index + 1];
-    const showAvatar = !isSystem && (!next || next.user_id !== item.user_id);
+    const showAvatar = !isSystem && item.id === lastByUser[item.user_id || 0];
 
     if (isSystem) {
       return (


### PR DESCRIPTION
## Summary
- show avatars only on the most recent message sent by each user in chat threads
- compute per-user last message and use to toggle avatar visibility

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689e55430a408320bfdc0a03915758ed