### PR TITLE
Display manager name on application decisions

### DIFF
--- a/mobile/src/lib/api.ts
+++ b/mobile/src/lib/api.ts
@@ -387,6 +387,7 @@ export async function getApplicationForChat(chatId: number): Promise<Application
 }
 
 export async function setApplicationStatus(chatId: number, status: "accepted" | "declined"): Promise<Application> {
+  const managerName = useAuth.getState().user?.username;
   if (API_BASE) {
     try {
       const token = useAuth.getState().token;
@@ -414,7 +415,7 @@ export async function setApplicationStatus(chatId: number, status: "accepted" | 
   const app = _applications.find(a => a.chatId === chatId);
   if (!app) throw new Error("Application not found");
   app.status = status;
-  await sendMessage(chatId, `Manager ${status} the application`, "system");
+  await sendMessage(chatId, `${managerName || "Manager"} ${status} the application`, "system");
   return Promise.resolve(app);
 }
 


### PR DESCRIPTION
## Summary
- include manager username when updating application status on the server
- show manager's name in mobile stub when sending application decision messages
- allow workers to apply to multiple jobs from the same manager by making applications unique per project-worker pair

## Testing
- `npm test` (server) *(fails: Missing script "test")*
- `npm test` (mobile) *(fails: Missing script "test")*
- `npm run lint` (mobile)


------
https://chatgpt.com/codex/tasks/task_e_689f36e601bc832088588a6c5cbb5bcf