### PR TITLE
Ensure job details reopen after returning from poster profile

### DIFF
--- a/mobile/app/(labourer)/jobs.tsx
+++ b/mobile/app/(labourer)/jobs.tsx
@@ -7,7 +7,8 @@ import { useAuth } from "@src/store/useAuth";
 import { useNotifications } from "@src/store/useNotifications";
 import { Colors } from "@src/theme/tokens";
 import { Ionicons } from "@expo/vector-icons";
-import { router } from "expo-router";
+import { router, useLocalSearchParams } from "expo-router";
+import { useProfile } from "@src/store/useProfile";
 
 type Filter = "all" | "open" | "in_progress" | "completed";
 
@@ -25,9 +26,12 @@ export default function Jobs() {
   const { isSaved, toggleSave } = useSaved();
   const { user } = useAuth();
   const { bump } = useNotifications();
+  const profiles = useProfile((s) => s.profiles);
+  const { jobId: jobParam } = useLocalSearchParams<{ jobId?: string }>();
 
   const [selected, setSelected] = useState<Job | null>(null);
   const [open, setOpen] = useState(false);
+  const [pendingProfile, setPendingProfile] = useState<{ userId: number; jobId: number } | null>(null);
 
   // Applied state for the selected job
   const [appliedChatId, setAppliedChatId] = useState<number | null>(null);
@@ -35,6 +39,17 @@ export default function Jobs() {
   const [checkingApplied, setCheckingApplied] = useState(false);
   const [applying, setApplying] = useState(false);
   const [localApplied, setLocalApplied] = useState<Record<number, { chatId: number; status: "pending" | "accepted" | "declined" }>>({});
+
+  useEffect(() => {
+    if (!open && pendingProfile) {
+      const { userId, jobId } = pendingProfile;
+      setPendingProfile(null);
+      router.push({
+        pathname: "/(labourer)/profileDetails",
+        params: { userId: String(userId), jobId: String(jobId), from: "jobs" },
+      });
+    }
+  }, [open, pendingProfile]);
 
   useEffect(() => {
     let cancelled = false;
@@ -67,6 +82,18 @@ export default function Jobs() {
       cancelled = true;
     };
   }, [user]);
+
+  useEffect(() => {
+    const jp = Array.isArray(jobParam) ? jobParam[0] : jobParam;
+    const id = jp ? parseInt(jp, 10) : NaN;
+    if (!isNaN(id)) {
+      const job = items.find((j) => j.id === id);
+      if (job) {
+        setSelected(job);
+        setOpen(true);
+      }
+    }
+  }, [jobParam, items]);
 
   const filtered = useMemo(
     () => (filter === "all" ? items : items.filter((j) => j.status === filter)),
@@ -234,7 +261,12 @@ export default function Jobs() {
       />
 
       {/* Details popup */}
-      <Modal visible={open} animationType="slide" presentationStyle="pageSheet" onRequestClose={() => setOpen(false)}>
+      <Modal
+        visible={open}
+        animationType="slide"
+        presentationStyle="pageSheet"
+        onRequestClose={() => setOpen(false)}
+      >
         <ScrollView contentContainerStyle={{ paddingBottom: 24 }}>
           <View
             style={{
@@ -255,6 +287,45 @@ export default function Jobs() {
           {selected?.imageUri ? <Image source={{ uri: selected.imageUri }} style={{ width: "100%", height: 220 }} /> : null}
 
           <View style={{ padding: 12, gap: 6 }}>
+            {selected ? (
+              <View style={{ flexDirection: "row", alignItems: "center", marginBottom: 4 }}>
+                <Pressable
+                  disabled={selected.ownerId == null}
+                  onPress={() => {
+                    if (selected.ownerId == null) return;
+                    router.setParams({ jobId: undefined });
+                    setPendingProfile({ userId: selected.ownerId, jobId: selected.id });
+                    setOpen(false);
+                  }}
+                  style={{ marginRight: 8 }}
+                >
+                  {selected.ownerId != null && profiles[selected.ownerId]?.avatarUri ? (
+                    <Image
+                      source={{ uri: profiles[selected.ownerId]!.avatarUri }}
+                      style={{ width: 32, height: 32, borderRadius: 16, backgroundColor: "#E5E7EB" }}
+                    />
+                  ) : (
+                    <View
+                      style={{
+                        width: 32,
+                        height: 32,
+                        borderRadius: 16,
+                        backgroundColor: "#E5E7EB",
+                        alignItems: "center",
+                        justifyContent: "center",
+                      }}
+                    >
+                      <Ionicons name="person" size={18} color="#9CA3AF" />
+                    </View>
+                  )}
+                </Pressable>
+                <Text style={{ color: "#6B7280" }}>
+                  Posted by {selected.ownerId != null
+                    ? profiles[selected.ownerId]?.name?.split(" ")[0] || "Manager"
+                    : "Manager"}
+                </Text>
+              </View>
+            ) : null}
             <View style={{ flexDirection: "row", alignItems: "center", gap: 8, flexWrap: "wrap" }}>
               <Text style={{ fontSize: 22, fontWeight: "800", color: "#1F2937" }}>{selected?.title}</Text>
               {appliedChatId ? (

--- a/mobile/app/(labourer)/map.tsx
+++ b/mobile/app/(labourer)/map.tsx
@@ -11,7 +11,8 @@ import { useSaved } from "@src/store/useSaved";
 import { useAuth } from "@src/store/useAuth";
 import { useNotifications } from "@src/store/useNotifications";
 import { Ionicons } from "@expo/vector-icons";
-import { router } from "expo-router";
+import { router, useLocalSearchParams } from "expo-router";
+import { useProfile } from "@src/store/useProfile";
 
 type MarkerLite = {
   id: number;
@@ -64,6 +65,7 @@ export default function LabourerMap() {
   const [selectedId, setSelectedId] = useState<number | null>(null);
 
   const [open, setOpen] = useState(false); // job details modal
+  const [pendingProfile, setPendingProfile] = useState<{ userId: number; jobId: number } | null>(null);
   const [appliedChatId, setAppliedChatId] = useState<number | null>(null);
   const [appliedStatus, setAppliedStatus] = useState<"pending" | "accepted" | "declined" | null>(null);
   const [checkingApplied, setCheckingApplied] = useState(false);
@@ -71,14 +73,36 @@ export default function LabourerMap() {
   // Force marker children to refresh briefly when selection changes (Android needs this)
   const [refreshMarkers, setRefreshMarkers] = useState(false);
 
+  useEffect(() => {
+    if (!open && pendingProfile) {
+      const { userId, jobId } = pendingProfile;
+      setPendingProfile(null);
+      router.push({
+        pathname: "/(labourer)/profileDetails",
+        params: { userId: String(userId), jobId: String(jobId), from: "map" },
+      });
+    }
+  }, [open, pendingProfile]);
+
   const mapRef = useRef<MapView>(null);
   const sheetY = useRef(new Animated.Value(200)).current;
 
   const { isSaved, toggleSave } = useSaved();
   const { user } = useAuth();
   const { bump } = useNotifications();
+  const profiles = useProfile((s) => s.profiles);
+  const { jobId: jobParam } = useLocalSearchParams<{ jobId?: string }>();
 
   const selectedJob = useMemo(() => jobs.find(j => j.id === selectedId) || null, [jobs, selectedId]);
+
+  useEffect(() => {
+    const jp = Array.isArray(jobParam) ? jobParam[0] : jobParam;
+    const id = jp ? parseInt(jp, 10) : NaN;
+    if (!isNaN(id)) {
+      setSelectedId(id);
+      setOpen(true);
+    }
+  }, [jobParam]);
 
   const load = async () => {
     const [locs, allJobs] = await Promise.all([listJobLocations(), listJobs()]);
@@ -246,7 +270,12 @@ export default function LabourerMap() {
       </Animated.View>
 
       {/* Job details modal */}
-      <Modal visible={open} animationType="slide" presentationStyle="pageSheet" onRequestClose={() => setOpen(false)}>
+      <Modal
+        visible={open}
+        animationType="slide"
+        presentationStyle="pageSheet"
+        onRequestClose={() => setOpen(false)}
+      >
         <ScrollView contentContainerStyle={{ paddingBottom: 24 }}>
           <View style={{ flexDirection: "row", alignItems: "center", justifyContent: "space-between", paddingHorizontal: 12, paddingVertical: 12 }}>
             <Pressable onPress={() => setOpen(false)} hitSlop={10}><Ionicons name="chevron-down" size={24} color="#6B7280" /></Pressable>
@@ -257,6 +286,45 @@ export default function LabourerMap() {
           {selectedJob?.imageUri ? <Image source={{ uri: selectedJob.imageUri }} style={{ width: "100%", height: 220 }} /> : null}
 
           <View style={{ padding: 12, gap: 6 }}>
+            {selectedJob ? (
+              <View style={{ flexDirection: "row", alignItems: "center", marginBottom: 4 }}>
+                <Pressable
+                  disabled={selectedJob.ownerId == null}
+                  onPress={() => {
+                    if (selectedJob.ownerId == null) return;
+                    router.setParams({ jobId: undefined });
+                    setPendingProfile({ userId: selectedJob.ownerId, jobId: selectedJob.id });
+                    setOpen(false);
+                  }}
+                  style={{ marginRight: 8 }}
+                >
+                  {selectedJob.ownerId != null && profiles[selectedJob.ownerId]?.avatarUri ? (
+                    <Image
+                      source={{ uri: profiles[selectedJob.ownerId]!.avatarUri }}
+                      style={{ width: 32, height: 32, borderRadius: 16, backgroundColor: "#E5E7EB" }}
+                    />
+                  ) : (
+                    <View
+                      style={{
+                        width: 32,
+                        height: 32,
+                        borderRadius: 16,
+                        backgroundColor: "#E5E7EB",
+                        alignItems: "center",
+                        justifyContent: "center",
+                      }}
+                    >
+                      <Ionicons name="person" size={18} color="#9CA3AF" />
+                    </View>
+                  )}
+                </Pressable>
+                <Text style={{ color: "#6B7280" }}>
+                  Posted by {selectedJob.ownerId != null
+                    ? profiles[selectedJob.ownerId]?.name?.split(" ")[0] || "Manager"
+                    : "Manager"}
+                </Text>
+              </View>
+            ) : null}
             <View style={{ flexDirection: "row", alignItems: "center", gap: 8, flexWrap: "wrap" }}>
               <Text style={{ fontSize: 22, fontWeight: "800", color: "#1F2937" }}>{selectedJob?.title}</Text>
               {appliedChatId ? (


### PR DESCRIPTION
## Summary
- clear jobId param before navigating to poster profile so returning always reopens the job modal
- apply same param reset for map view jobs

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68a4a751efdc8320bab2058cf57bcecb