### PR TITLE
Link job and chat views to user profiles

### DIFF
--- a/mobile/app/(labourer)/jobs.tsx
+++ b/mobile/app/(labourer)/jobs.tsx
@@ -7,7 +7,8 @@ import { useAuth } from "@src/store/useAuth";
 import { useNotifications } from "@src/store/useNotifications";
 import { Colors } from "@src/theme/tokens";
 import { Ionicons } from "@expo/vector-icons";
-import { router } from "expo-router";
+import { router, useLocalSearchParams } from "expo-router";
+import { useProfile } from "@src/store/useProfile";
 
 type Filter = "all" | "open" | "in_progress" | "completed";
 
@@ -25,9 +26,12 @@ export default function Jobs() {
   const { isSaved, toggleSave } = useSaved();
   const { user } = useAuth();
   const { bump } = useNotifications();
+  const profiles = useProfile((s) => s.profiles);
+  const { jobId: jobParam } = useLocalSearchParams<{ jobId?: string }>();
 
   const [selected, setSelected] = useState<Job | null>(null);
   const [open, setOpen] = useState(false);
+  const [pendingProfile, setPendingProfile] = useState<{ userId: number; jobId: number } | null>(null);
 
   // Applied state for the selected job
   const [appliedChatId, setAppliedChatId] = useState<number | null>(null);
@@ -35,6 +39,17 @@ export default function Jobs() {
   const [checkingApplied, setCheckingApplied] = useState(false);
   const [applying, setApplying] = useState(false);
   const [localApplied, setLocalApplied] = useState<Record<number, { chatId: number; status: "pending" | "accepted" | "declined" }>>({});
+
+  useEffect(() => {
+    if (!open && pendingProfile) {
+      const { userId, jobId } = pendingProfile;
+      setPendingProfile(null);
+      router.push({
+        pathname: "/(labourer)/profileDetails",
+        params: { userId: String(userId), jobId: String(jobId), from: "jobs" },
+      });
+    }
+  }, [open, pendingProfile]);
 
   useEffect(() => {
     let cancelled = false;
@@ -67,6 +82,18 @@ export default function Jobs() {
       cancelled = true;
     };
   }, [user]);
+
+  useEffect(() => {
+    const jp = Array.isArray(jobParam) ? jobParam[0] : jobParam;
+    const id = jp ? parseInt(jp, 10) : NaN;
+    if (!isNaN(id)) {
+      const job = items.find((j) => j.id === id);
+      if (job) {
+        setSelected(job);
+        setOpen(true);
+      }
+    }
+  }, [jobParam, items]);
 
   const filtered = useMemo(
     () => (filter === "all" ? items : items.filter((j) => j.status === filter)),
@@ -234,7 +261,12 @@ export default function Jobs() {
       />
 
       {/* Details popup */}
-      <Modal visible={open} animationType="slide" presentationStyle="pageSheet" onRequestClose={() => setOpen(false)}>
+      <Modal
+        visible={open}
+        animationType="slide"
+        presentationStyle="pageSheet"
+        onRequestClose={() => setOpen(false)}
+      >
         <ScrollView contentContainerStyle={{ paddingBottom: 24 }}>
           <View
             style={{
@@ -255,6 +287,45 @@ export default function Jobs() {
           {selected?.imageUri ? <Image source={{ uri: selected.imageUri }} style={{ width: "100%", height: 220 }} /> : null}
 
           <View style={{ padding: 12, gap: 6 }}>
+            {selected ? (
+              <View style={{ flexDirection: "row", alignItems: "center", marginBottom: 4 }}>
+                <Pressable
+                  disabled={selected.ownerId == null}
+                  onPress={() => {
+                    if (selected.ownerId == null) return;
+                    router.setParams({ jobId: undefined });
+                    setPendingProfile({ userId: selected.ownerId, jobId: selected.id });
+                    setOpen(false);
+                  }}
+                  style={{ marginRight: 8 }}
+                >
+                  {selected.ownerId != null && profiles[selected.ownerId]?.avatarUri ? (
+                    <Image
+                      source={{ uri: profiles[selected.ownerId]!.avatarUri }}
+                      style={{ width: 32, height: 32, borderRadius: 16, backgroundColor: "#E5E7EB" }}
+                    />
+                  ) : (
+                    <View
+                      style={{
+                        width: 32,
+                        height: 32,
+                        borderRadius: 16,
+                        backgroundColor: "#E5E7EB",
+                        alignItems: "center",
+                        justifyContent: "center",
+                      }}
+                    >
+                      <Ionicons name="person" size={18} color="#9CA3AF" />
+                    </View>
+                  )}
+                </Pressable>
+                <Text style={{ color: "#6B7280" }}>
+                  Posted by {selected.ownerId != null
+                    ? profiles[selected.ownerId]?.name?.split(" ")[0] || "Manager"
+                    : "Manager"}
+                </Text>
+              </View>
+            ) : null}
             <View style={{ flexDirection: "row", alignItems: "center", gap: 8, flexWrap: "wrap" }}>
               <Text style={{ fontSize: 22, fontWeight: "800", color: "#1F2937" }}>{selected?.title}</Text>
               {appliedChatId ? (

--- a/mobile/app/(labourer)/map.tsx
+++ b/mobile/app/(labourer)/map.tsx
@@ -11,7 +11,8 @@ import { useSaved } from "@src/store/useSaved";
 import { useAuth } from "@src/store/useAuth";
 import { useNotifications } from "@src/store/useNotifications";
 import { Ionicons } from "@expo/vector-icons";
-import { router } from "expo-router";
+import { router, useLocalSearchParams } from "expo-router";
+import { useProfile } from "@src/store/useProfile";
 
 type MarkerLite = {
   id: number;
@@ -64,6 +65,7 @@ export default function LabourerMap() {
   const [selectedId, setSelectedId] = useState<number | null>(null);
 
   const [open, setOpen] = useState(false); // job details modal
+  const [pendingProfile, setPendingProfile] = useState<{ userId: number; jobId: number } | null>(null);
   const [appliedChatId, setAppliedChatId] = useState<number | null>(null);
   const [appliedStatus, setAppliedStatus] = useState<"pending" | "accepted" | "declined" | null>(null);
   const [checkingApplied, setCheckingApplied] = useState(false);
@@ -71,14 +73,36 @@ export default function LabourerMap() {
   // Force marker children to refresh briefly when selection changes (Android needs this)
   const [refreshMarkers, setRefreshMarkers] = useState(false);
 
+  useEffect(() => {
+    if (!open && pendingProfile) {
+      const { userId, jobId } = pendingProfile;
+      setPendingProfile(null);
+      router.push({
+        pathname: "/(labourer)/profileDetails",
+        params: { userId: String(userId), jobId: String(jobId), from: "map" },
+      });
+    }
+  }, [open, pendingProfile]);
+
   const mapRef = useRef<MapView>(null);
   const sheetY = useRef(new Animated.Value(200)).current;
 
   const { isSaved, toggleSave } = useSaved();
   const { user } = useAuth();
   const { bump } = useNotifications();
+  const profiles = useProfile((s) => s.profiles);
+  const { jobId: jobParam } = useLocalSearchParams<{ jobId?: string }>();
 
   const selectedJob = useMemo(() => jobs.find(j => j.id === selectedId) || null, [jobs, selectedId]);
+
+  useEffect(() => {
+    const jp = Array.isArray(jobParam) ? jobParam[0] : jobParam;
+    const id = jp ? parseInt(jp, 10) : NaN;
+    if (!isNaN(id)) {
+      setSelectedId(id);
+      setOpen(true);
+    }
+  }, [jobParam]);
 
   const load = async () => {
     const [locs, allJobs] = await Promise.all([listJobLocations(), listJobs()]);
@@ -246,7 +270,12 @@ export default function LabourerMap() {
       </Animated.View>
 
       {/* Job details modal */}
-      <Modal visible={open} animationType="slide" presentationStyle="pageSheet" onRequestClose={() => setOpen(false)}>
+      <Modal
+        visible={open}
+        animationType="slide"
+        presentationStyle="pageSheet"
+        onRequestClose={() => setOpen(false)}
+      >
         <ScrollView contentContainerStyle={{ paddingBottom: 24 }}>
           <View style={{ flexDirection: "row", alignItems: "center", justifyContent: "space-between", paddingHorizontal: 12, paddingVertical: 12 }}>
             <Pressable onPress={() => setOpen(false)} hitSlop={10}><Ionicons name="chevron-down" size={24} color="#6B7280" /></Pressable>
@@ -257,6 +286,45 @@ export default function LabourerMap() {
           {selectedJob?.imageUri ? <Image source={{ uri: selectedJob.imageUri }} style={{ width: "100%", height: 220 }} /> : null}
 
           <View style={{ padding: 12, gap: 6 }}>
+            {selectedJob ? (
+              <View style={{ flexDirection: "row", alignItems: "center", marginBottom: 4 }}>
+                <Pressable
+                  disabled={selectedJob.ownerId == null}
+                  onPress={() => {
+                    if (selectedJob.ownerId == null) return;
+                    router.setParams({ jobId: undefined });
+                    setPendingProfile({ userId: selectedJob.ownerId, jobId: selectedJob.id });
+                    setOpen(false);
+                  }}
+                  style={{ marginRight: 8 }}
+                >
+                  {selectedJob.ownerId != null && profiles[selectedJob.ownerId]?.avatarUri ? (
+                    <Image
+                      source={{ uri: profiles[selectedJob.ownerId]!.avatarUri }}
+                      style={{ width: 32, height: 32, borderRadius: 16, backgroundColor: "#E5E7EB" }}
+                    />
+                  ) : (
+                    <View
+                      style={{
+                        width: 32,
+                        height: 32,
+                        borderRadius: 16,
+                        backgroundColor: "#E5E7EB",
+                        alignItems: "center",
+                        justifyContent: "center",
+                      }}
+                    >
+                      <Ionicons name="person" size={18} color="#9CA3AF" />
+                    </View>
+                  )}
+                </Pressable>
+                <Text style={{ color: "#6B7280" }}>
+                  Posted by {selectedJob.ownerId != null
+                    ? profiles[selectedJob.ownerId]?.name?.split(" ")[0] || "Manager"
+                    : "Manager"}
+                </Text>
+              </View>
+            ) : null}
             <View style={{ flexDirection: "row", alignItems: "center", gap: 8, flexWrap: "wrap" }}>
               <Text style={{ fontSize: 22, fontWeight: "800", color: "#1F2937" }}>{selectedJob?.title}</Text>
               {appliedChatId ? (

--- a/mobile/app/(labourer)/profileDetails.tsx
+++ b/mobile/app/(labourer)/profileDetails.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from "react";
+import React, { useEffect, useState, useRef } from "react";
 import {
   View,
   Text,
@@ -9,6 +9,8 @@ import {
   TextInput,
   KeyboardAvoidingView,
   Platform,
+  Dimensions,
+  Animated,
 } from "react-native";
 import { Stack, router, useLocalSearchParams } from "expo-router";
 import * as ImagePicker from "expo-image-picker";
@@ -40,6 +42,9 @@ export default function LabourerProfileDetails() {
       : params.from
     : undefined;
   const isOwn = viewUserId === authUserId;
+
+  const screenW = Dimensions.get("window").width;
+  const translateX = useRef(new Animated.Value(0)).current;
 
   const profiles = useProfile((s) => s.profiles);
   const upsertProfile = useProfile((s) => s.upsertProfile);
@@ -155,13 +160,17 @@ export default function LabourerProfileDetails() {
         behavior={Platform.OS === "ios" ? "padding" : undefined}
         keyboardVerticalOffset={Platform.OS === "ios" ? insets.top : 0}
       >
-        <View style={{ flex: 1 }}>
+        <Animated.View style={{ flex: 1, transform: [{ translateX }] }}>
           {/* FIXED Top bar (outside the ScrollView) */}
           <View style={[styles.topBar, { paddingTop: insets.top + 6 }]}>
             <Pressable
               onPress={() => {
                 if (backChatId) {
-                  router.back();
+                  Animated.timing(translateX, {
+                    toValue: screenW,
+                    duration: 160,
+                    useNativeDriver: true,
+                  }).start(() => router.back());
                   return;
                 }
                 if (backJobId) {
@@ -436,7 +445,7 @@ export default function LabourerProfileDetails() {
               </View>
             )}
           </ScrollView>
-        </View>
+        </Animated.View>
       </KeyboardAvoidingView>
     </>
   );

--- a/mobile/app/(labourer)/profileDetails.tsx
+++ b/mobile/app/(labourer)/profileDetails.tsx
@@ -10,7 +10,7 @@ import {
   KeyboardAvoidingView,
   Platform,
 } from "react-native";
-import { Stack, router } from "expo-router";
+import { Stack, router, useLocalSearchParams } from "expo-router";
 import * as ImagePicker from "expo-image-picker";
 import { Ionicons } from "@expo/vector-icons";
 import { Colors } from "@src/theme/tokens";
@@ -23,7 +23,23 @@ const BACK_TO = "/(labourer)/profile";
 export default function LabourerProfileDetails() {
   const insets = useSafeAreaInsets();
   const { user } = useAuth();
-  const userId = user?.id ?? 0;
+  const authUserId = user?.id ?? 0;
+  const params = useLocalSearchParams<{ userId?: string; jobId?: string; from?: string; chatId?: string }>();
+  const viewUserId = params.userId
+    ? parseInt(Array.isArray(params.userId) ? params.userId[0] : params.userId, 10)
+    : authUserId;
+  const backJobId = params.jobId
+    ? Array.isArray(params.jobId) ? params.jobId[0] : params.jobId
+    : undefined;
+  const backChatId = params.chatId
+    ? Array.isArray(params.chatId) ? params.chatId[0] : params.chatId
+    : undefined;
+  const from = params.from
+    ? Array.isArray(params.from)
+      ? params.from[0]
+      : params.from
+    : undefined;
+  const isOwn = viewUserId === authUserId;
 
   const profiles = useProfile((s) => s.profiles);
   const upsertProfile = useProfile((s) => s.upsertProfile);
@@ -37,18 +53,23 @@ export default function LabourerProfileDetails() {
   const removeQualification = useProfile((s) => s.removeQualification);
 
   useEffect(() => {
-    if (!user) return;
-    if (!profiles[user.id]) {
-      upsertProfile(
-        defaultProfile(user.id, user.username ?? "You", (user.role ?? "labourer") as any)
-      );
+    if (!profiles[viewUserId]) {
+      if (isOwn && user) {
+        upsertProfile(
+          defaultProfile(viewUserId, user.username ?? "You", (user.role ?? "labourer") as any)
+        );
+      } else {
+        upsertProfile(defaultProfile(viewUserId, "Manager", "manager"));
+      }
     }
-  }, [user?.id]);
+  }, [viewUserId, profiles, isOwn, user, upsertProfile]);
 
-  const profile = profiles[userId];
+  const profile = profiles[viewUserId];
 
   const [editing, setEditing] = useState(false);
-  const [name, setName] = useState(profile?.name ?? user?.username ?? "You");
+  const [name, setName] = useState(
+    profile?.name ?? (isOwn ? user?.username ?? "You" : "Name")
+  );
   const [headline, setHeadline] = useState(profile?.headline ?? "Looking for work");
   const [location, setLocation] = useState(profile?.location ?? "Brighton, UK");
   const [company, setCompany] = useState(profile?.company ?? "");
@@ -65,11 +86,15 @@ export default function LabourerProfileDetails() {
       setCompany(profile.company ?? "");
       setBio(profile.bio ?? "");
     }
-  }, [profile?.userId]);
+  }, [profile]);
+
+  useEffect(() => {
+    if (!isOwn) setEditing(false);
+  }, [isOwn, viewUserId]);
 
   const save = () => {
-    if (!user) return;
-    updateProfile(user.id, {
+    if (!user || !isOwn) return;
+    updateProfile(viewUserId, {
       name: name.trim(),
       headline: headline.trim(),
       location: location.trim(),
@@ -86,7 +111,7 @@ export default function LabourerProfileDetails() {
       mediaTypes: ImagePicker.MediaTypeOptions.Images,
     });
     if (!res.canceled && res.assets?.length) {
-      updateProfile(userId, { [field]: res.assets[0].uri } as any);
+      updateProfile(viewUserId, { [field]: res.assets[0].uri } as any);
     }
   };
 
@@ -97,12 +122,12 @@ export default function LabourerProfileDetails() {
       mediaTypes: ImagePicker.MediaTypeOptions.Images,
     });
     if (!res.canceled && res.assets?.length) {
-      updateQualification(userId, id, { imageUri: res.assets[0].uri });
+      updateQualification(viewUserId, id, { imageUri: res.assets[0].uri });
     }
   };
 
   const addQual = () => {
-    addQualification(userId, {
+    addQualification(viewUserId, {
       id: String(Date.now()),
       title: "New Qualification",
       status: "pending",
@@ -133,15 +158,33 @@ export default function LabourerProfileDetails() {
         <View style={{ flex: 1 }}>
           {/* FIXED Top bar (outside the ScrollView) */}
           <View style={[styles.topBar, { paddingTop: insets.top + 6 }]}>
-            <Pressable onPress={() => router.replace(BACK_TO)} hitSlop={12}>
+            <Pressable
+              onPress={() => {
+                if (backChatId) {
+                  router.back();
+                  return;
+                }
+                if (backJobId) {
+                  const dest = from === "jobs" ? "/(labourer)/jobs" : "/(labourer)/map";
+                  router.replace({ pathname: dest, params: { jobId: String(backJobId) } });
+                } else {
+                  router.replace(BACK_TO);
+                }
+              }}
+              hitSlop={12}
+            >
               <Ionicons name="chevron-back" size={24} color="#111" />
             </Pressable>
 
             <Text style={styles.topTitle}>Profile</Text>
 
-            <Pressable onPress={() => setEditing((e) => !e)} hitSlop={12}>
-              <Ionicons name={editing ? "close" : "pencil"} size={22} color="#6B7280" />
-            </Pressable>
+            {isOwn ? (
+              <Pressable onPress={() => setEditing((e) => !e)} hitSlop={12}>
+                <Ionicons name={editing ? "close" : "pencil"} size={22} color="#6B7280" />
+              </Pressable>
+            ) : (
+              <View style={{ width: 22 }} />
+            )}
           </View>
 
           <ScrollView
@@ -308,7 +351,7 @@ export default function LabourerProfileDetails() {
                         <TextInput
                           value={q.title}
                           onChangeText={(t) =>
-                            updateQualification(userId, q.id, { title: t })
+                            updateQualification(viewUserId, q.id, { title: t })
                           }
                           style={styles.input}
                           placeholder="Title"
@@ -332,7 +375,7 @@ export default function LabourerProfileDetails() {
 
                     {editing ? (
                       <Pressable
-                        onPress={() => removeQualification(userId, q.id)}
+                        onPress={() => removeQualification(viewUserId, q.id)}
                         style={[styles.btnIcon, { borderColor: "#ef4444" }]}
                         hitSlop={6}
                       >
@@ -354,10 +397,10 @@ export default function LabourerProfileDetails() {
                 onChangeNew={setNewSkill}
                 onAdd={() => {
                   if (!newSkill.trim()) return;
-                  addSkill(userId, newSkill.trim());
+                  addSkill(viewUserId, newSkill.trim());
                   setNewSkill("");
                 }}
-                onRemove={(s) => removeSkill(userId, s)}
+                onRemove={(s) => removeSkill(viewUserId, s)}
               />
             )}
 
@@ -371,10 +414,10 @@ export default function LabourerProfileDetails() {
                 onChangeNew={setNewInterest}
                 onAdd={() => {
                   if (!newInterest.trim()) return;
-                  addInterest(userId, newInterest.trim());
+                  addInterest(viewUserId, newInterest.trim());
                   setNewInterest("");
                 }}
-                onRemove={(s) => removeInterest(userId, s)}
+                onRemove={(s) => removeInterest(viewUserId, s)}
               />
             )}
 


### PR DESCRIPTION
## Summary
- clear jobId param before navigating to poster profile so returning always reopens the job modal
- apply same param reset for map view jobs
- show chat partner's avatar next to their name and link the header to the user profile, returning to the chat when backing out
- use router.back for profile back button when opened from chat

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a4a751efdc8320bab2058cf57bcecb