### PR TITLE
Fix back navigation from profile opened in chat

### DIFF
--- a/mobile/app/(labourer)/profileDetails.tsx
+++ b/mobile/app/(labourer)/profileDetails.tsx
@@ -54,7 +54,8 @@ export default function LabourerProfileDetails() {
           defaultProfile(viewUserId, user.username ?? "You", (user.role ?? "labourer") as any)
         );
       } else {
-        upsertProfile(defaultProfile(viewUserId, "Manager", "manager"));
+        // Viewing another labourer profile
+        upsertProfile(defaultProfile(viewUserId, "Worker", "labourer"));
       }
     }
   }, [viewUserId, profiles, isOwn, user, upsertProfile]);

--- a/mobile/app/(labourer)/profileDetails.tsx
+++ b/mobile/app/(labourer)/profileDetails.tsx
@@ -18,8 +18,6 @@ import { useAuth } from "@src/store/useAuth";
 import { useProfile, defaultProfile } from "@src/store/useProfile";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
 
-const BACK_TO = "/(labourer)/profile";
-
 export default function LabourerProfileDetails() {
   const insets = useSafeAreaInsets();
   const { user } = useAuth();
@@ -161,7 +159,7 @@ export default function LabourerProfileDetails() {
                   const dest = from === "jobs" ? "/(labourer)/jobs" : "/(labourer)/map";
                   router.replace({ pathname: dest, params: { jobId: String(backJobId) } });
                 } else {
-                  router.replace(BACK_TO);
+                  router.back();
                 }
               }}
               hitSlop={12}

--- a/mobile/app/(manager)/chats/[id].tsx
+++ b/mobile/app/(manager)/chats/[id].tsx
@@ -20,7 +20,7 @@ import { Stack, router, useLocalSearchParams } from "expo-router";
 import { useFocusEffect } from "@react-navigation/native";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
 import { Colors } from "@src/theme/tokens";
-  import {
+import {
     listMessages,
     sendMessage,
     getChat,
@@ -225,6 +225,18 @@ export default function ManagerChatDetail() {
     return other;
   }, [messages, myName, chat]);
 
+  const workerId = chat?.workerId;
+  const workerAvatarUri = workerId ? profiles[workerId]?.avatarUri : undefined;
+
+  const goToProfile = useCallback(() => {
+    if (workerId) {
+      router.push({
+        pathname: "/(labourer)/profileDetails",
+        params: { userId: String(workerId), from: "chats" },
+      });
+    }
+  }, [workerId]);
+
   const lastByUser = useMemo(() => {
     const map: Record<number, number> = {};
     for (let i = messages.length - 1; i >= 0; i--) {
@@ -250,12 +262,16 @@ export default function ManagerChatDetail() {
       );
     }
 
-    const avatar = avatarUri ? (
+    const avatarEl = avatarUri ? (
       <Image source={{ uri: avatarUri }} style={styles.avatar} />
     ) : (
       <View style={[styles.avatar, styles.silhouette]}>
         <Ionicons name="person" size={18} color="#9CA3AF" />
       </View>
+    );
+
+    const avatar = isMine ? avatarEl : (
+      <Pressable onPress={goToProfile}>{avatarEl}</Pressable>
     );
 
     return (
@@ -295,9 +311,22 @@ export default function ManagerChatDetail() {
             <Pressable onPress={goToList} hitSlop={12}>
               <Text style={styles.headerBack}>‹</Text>
             </Pressable>
-            <Text style={styles.headerTitle} numberOfLines={1}>
-              {otherPartyName}
-            </Text>
+            <Pressable
+              style={styles.headerProfile}
+              onPress={goToProfile}
+              hitSlop={8}
+            >
+              {workerAvatarUri ? (
+                <Image source={{ uri: workerAvatarUri }} style={styles.headerAvatar} />
+              ) : (
+                <View style={[styles.headerAvatar, styles.silhouette]}>
+                  <Ionicons name="person" size={18} color="#9CA3AF" />
+                </View>
+              )}
+              <Text style={styles.headerTitle} numberOfLines={1}>
+                {otherPartyName}
+              </Text>
+            </Pressable>
             <View style={{ width: 18 }} />
           </View>
 
@@ -401,6 +430,8 @@ const styles = StyleSheet.create({
     gap: 8,
   },
   headerBack: { fontSize: 26, lineHeight: 26, color: "#6B7280", paddingRight: 6 },
+  headerProfile: { flex: 1, flexDirection: "row", alignItems: "center", gap: 8 },
+  headerAvatar: { width: 32, height: 32, borderRadius: 16, backgroundColor: "#E5E7EB" },
   headerTitle: { flex: 1, fontSize: 18, fontWeight: "600", color: "#111" },
 
   statusRow: {

--- a/mobile/app/(manager)/profileDetails.tsx
+++ b/mobile/app/(manager)/profileDetails.tsx
@@ -18,8 +18,6 @@ import { useAuth } from "@src/store/useAuth";
 import { useProfile, defaultProfile } from "@src/store/useProfile";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
 
-const BACK_TO = "/(manager)/profile";
-
 export default function ManagerProfileDetails() {
   const insets = useSafeAreaInsets();
   const { user } = useAuth();
@@ -131,7 +129,12 @@ export default function ManagerProfileDetails() {
         <View style={{ flex: 1 }}>
           {/* FIXED Top bar (outside the ScrollView) */}
           <View style={[styles.topBar, { paddingTop: insets.top + 6 }]}>
-            <Pressable onPress={() => router.replace(BACK_TO)} hitSlop={12}>
+            <Pressable
+              onPress={() => {
+                router.back();
+              }}
+              hitSlop={12}
+            >
               <Ionicons name="chevron-back" size={24} color="#111" />
             </Pressable>
 


### PR DESCRIPTION
## Summary
- Always call `router.back()` from profile detail chevrons so chat-to-profile navigation returns to the chat

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68a4dece65b08320a3cac58c69944df7