### PR TITLE
Show user info in chat header

### DIFF
--- a/mobile/app/(labourer)/chats/[id].tsx
+++ b/mobile/app/(labourer)/chats/[id].tsx
@@ -45,6 +45,7 @@ export default function LabourerChatDetail() {
   const myId = user?.id ?? 0;
   const myName = user?.username ?? "You";
   const profiles = useProfile((s) => s.profiles);
+  const ensureProfile = useProfile((s) => s.ensureProfile);
 
   const insets = useSafeAreaInsets();
 
@@ -107,6 +108,23 @@ export default function LabourerChatDetail() {
       };
     }
   }, [chatId]);
+
+  // Ensure we know the profile of the other party
+  useEffect(() => {
+    if (!chat) return;
+    const otherId = myId === chat.managerId ? chat.workerId : chat.managerId;
+    if (otherId) {
+      const role = otherId === chat.managerId ? "manager" : "labourer";
+      const nameFromMsg = messages.find(
+        (m) => m.user_id === otherId && m.username !== "system"
+      )?.username;
+      ensureProfile(
+        otherId,
+        nameFromMsg || (role === "manager" ? "Manager" : "Labourer"),
+        role
+      );
+    }
+  }, [chat, myId, messages, ensureProfile]);
 
   const onSend = useCallback(async () => {
     const body = input.trim();
@@ -198,13 +216,20 @@ export default function LabourerChatDetail() {
     []
   );
 
+  const otherPartyId = useMemo(() => {
+    if (!chat) return undefined;
+    return myId === chat.managerId ? chat.workerId : chat.managerId;
+  }, [chat, myId]);
+
+  const otherProfile = otherPartyId ? profiles[otherPartyId] : undefined;
+
   const otherPartyName = useMemo(() => {
-    const other =
-      messages.find((m) => m.username !== myName && m.username !== "system")?.username ||
-      chat?.title ||
-      "Chat";
-    return other;
-  }, [messages, myName, chat]);
+    if (otherProfile?.name) return otherProfile.name;
+    const msgName = messages.find(
+      (m) => m.user_id !== myId && m.username !== "system"
+    )?.username;
+    return msgName || chat?.title || "Chat";
+  }, [otherProfile, messages, myId, chat]);
 
   const lastByUser = useMemo(() => {
     const map: Record<number, number> = {};
@@ -276,6 +301,15 @@ export default function LabourerChatDetail() {
             <Pressable onPress={goToList} hitSlop={12}>
               <Text style={styles.headerBack}>‹</Text>
             </Pressable>
+            {otherPartyId ? (
+              otherProfile?.avatarUri ? (
+                <Image source={{ uri: otherProfile.avatarUri }} style={styles.avatar} />
+              ) : (
+                <View style={[styles.avatar, styles.silhouette]}>
+                  <Ionicons name="person" size={18} color="#9CA3AF" />
+                </View>
+              )
+            ) : null}
             <Text style={styles.headerTitle} numberOfLines={1}>
               {otherPartyName}
             </Text>

--- a/mobile/app/(manager)/chats/[id].tsx
+++ b/mobile/app/(manager)/chats/[id].tsx
@@ -46,6 +46,7 @@ export default function ManagerChatDetail() {
   const myId = user?.id ?? 0;
   const myName = user?.username ?? "You";
   const profiles = useProfile((s) => s.profiles);
+  const ensureProfile = useProfile((s) => s.ensureProfile);
 
   const insets = useSafeAreaInsets();
 
@@ -109,6 +110,23 @@ export default function ManagerChatDetail() {
       };
     }
   }, [chatId]);
+
+  // Ensure we know the profile of the other party
+  useEffect(() => {
+    if (!chat) return;
+    const otherId = myId === chat.managerId ? chat.workerId : chat.managerId;
+    if (otherId) {
+      const role = otherId === chat.managerId ? "manager" : "labourer";
+      const nameFromMsg = messages.find(
+        (m) => m.user_id === otherId && m.username !== "system"
+      )?.username;
+      ensureProfile(
+        otherId,
+        nameFromMsg || (role === "manager" ? "Manager" : "Labourer"),
+        role
+      );
+    }
+  }, [chat, myId, messages, ensureProfile]);
 
   const onSend = useCallback(async () => {
     const body = input.trim();
@@ -217,13 +235,20 @@ export default function ManagerChatDetail() {
     []
   );
 
+  const otherPartyId = useMemo(() => {
+    if (!chat) return undefined;
+    return myId === chat.managerId ? chat.workerId : chat.managerId;
+  }, [chat, myId]);
+
+  const otherProfile = otherPartyId ? profiles[otherPartyId] : undefined;
+
   const otherPartyName = useMemo(() => {
-    const other =
-      messages.find((m) => m.username !== myName && m.username !== "system")?.username ||
-      chat?.title ||
-      "Chat";
-    return other;
-  }, [messages, myName, chat]);
+    if (otherProfile?.name) return otherProfile.name;
+    const msgName = messages.find(
+      (m) => m.user_id !== myId && m.username !== "system"
+    )?.username;
+    return msgName || chat?.title || "Chat";
+  }, [otherProfile, messages, myId, chat]);
 
   const lastByUser = useMemo(() => {
     const map: Record<number, number> = {};
@@ -295,6 +320,15 @@ export default function ManagerChatDetail() {
             <Pressable onPress={goToList} hitSlop={12}>
               <Text style={styles.headerBack}>‹</Text>
             </Pressable>
+            {otherPartyId ? (
+              otherProfile?.avatarUri ? (
+                <Image source={{ uri: otherProfile.avatarUri }} style={styles.avatar} />
+              ) : (
+                <View style={[styles.avatar, styles.silhouette]}>
+                  <Ionicons name="person" size={18} color="#9CA3AF" />
+                </View>
+              )
+            ) : null}
             <Text style={styles.headerTitle} numberOfLines={1}>
               {otherPartyName}
             </Text>


### PR DESCRIPTION
## Summary
- Fetch the other participant's profile using their latest message to populate name and avatar
- Derive chat header titles from profile or message sender so both parties see the other's name

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a5ff84c6cc832085987ce2e1c1d799