### PR TITLE
feat: swipe-to-delete chats

### DIFF
--- a/mobile/app/(labourer)/chats.tsx
+++ b/mobile/app/(labourer)/chats.tsx
@@ -31,8 +31,8 @@ export default function Chats() {
         text: "Delete",
         style: "destructive",
         onPress: async () => {
+          setItems((prev) => prev.filter((c) => c.id !== id));
           await deleteChat(id);
-          load();
         },
       },
     ]);

--- a/mobile/app/(labourer)/chats/[id].tsx
+++ b/mobile/app/(labourer)/chats/[id].tsx
@@ -118,9 +118,11 @@ export default function LabourerChatDetail() {
       const nameFromMsg = messages.find(
         (m) => m.user_id === otherId && m.username !== "system"
       )?.username;
+      const titleName =
+        chat.title && !chat.title.startsWith("Job:") ? chat.title : undefined;
       ensureProfile(
         otherId,
-        nameFromMsg || (role === "manager" ? "Manager" : "Labourer"),
+        nameFromMsg || titleName || (role === "manager" ? "Manager" : "Labourer"),
         role
       );
     }
@@ -228,7 +230,14 @@ export default function LabourerChatDetail() {
     const msgName = messages.find(
       (m) => m.user_id !== myId && m.username !== "system"
     )?.username;
-    return msgName || chat?.title || "Chat";
+    if (msgName) return msgName;
+    const titleName =
+      chat?.title && !chat.title.startsWith("Job:") ? chat.title : undefined;
+    if (titleName) return titleName;
+    if (chat) {
+      return myId === chat.managerId ? "Labourer" : "Manager";
+    }
+    return "Chat";
   }, [otherProfile, messages, myId, chat]);
 
   const lastByUser = useMemo(() => {

--- a/mobile/app/(manager)/chats.tsx
+++ b/mobile/app/(manager)/chats.tsx
@@ -31,8 +31,8 @@ export default function Chats() {
         text: "Delete",
         style: "destructive",
         onPress: async () => {
+          setItems((prev) => prev.filter((c) => c.id !== id));
           await deleteChat(id);
-          load();
         },
       },
     ]);

--- a/mobile/app/(manager)/chats.tsx
+++ b/mobile/app/(manager)/chats.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useState, useCallback } from "react";
-import { View, FlatList, Text, Pressable, StyleSheet, Image } from "react-native";
+import { View, FlatList, Text, Pressable, StyleSheet, Image, Alert } from "react-native";
 import TopBar from "@src/components/TopBar";
-import { listChats, type Chat } from "@src/lib/api";
+import { listChats, type Chat, deleteChat } from "@src/lib/api";
 import { parseDate } from "@src/lib/date";
 import { useAuth } from "@src/store/useAuth";
 import { useFocusEffect, router } from "expo-router";
@@ -9,6 +9,7 @@ import { useNotifications } from "@src/store/useNotifications";
 import { Ionicons } from "@expo/vector-icons";
 import { useProfile } from "@src/store/useProfile";
 import { useChatBadge } from "@src/store/useChatBadge";
+import { Swipeable } from "react-native-gesture-handler";
 
 export default function Chats() {
   const { user } = useAuth();
@@ -21,6 +22,20 @@ export default function Chats() {
   const load = async () => {
     const data = await listChats(user?.id);
     setItems(Array.isArray(data) ? data : []);
+  };
+
+  const handleDelete = (id: number) => {
+    Alert.alert("Delete chat?", "Are you sure you want to delete chat?", [
+      { text: "Cancel", style: "cancel" },
+      {
+        text: "Delete",
+        style: "destructive",
+        onPress: async () => {
+          await deleteChat(id);
+          load();
+        },
+      },
+    ]);
   };
 
   useFocusEffect(
@@ -45,30 +60,39 @@ export default function Chats() {
       : false;
 
     return (
-      <Pressable
-        onPress={() => router.push(`/(manager)/chats/${item.id}`)}
-        style={styles.row}
-      >
-        {avatarUri ? (
-          <Image source={{ uri: avatarUri }} style={styles.avatar} />
-        ) : (
-          <View style={[styles.avatar, styles.silhouette]}>
-            <Ionicons name="person" size={18} color="#9CA3AF" />
-          </View>
+      <Swipeable
+        renderRightActions={() => (
+          <Pressable style={styles.delete} onPress={() => handleDelete(item.id)}>
+            <Ionicons name="trash" size={20} color="#fff" />
+            <Text style={styles.deleteText}>Delete</Text>
+          </Pressable>
         )}
-
-        <View style={{ flex: 1 }}>
-          <Text style={styles.title} numberOfLines={1}>{item.title || "Chat"}</Text>
-          {!!item.lastMessage && (
-            <Text style={styles.sub} numberOfLines={1}>{item.lastMessage}</Text>
+      >
+        <Pressable
+          onPress={() => router.push(`/(manager)/chats/${item.id}`)}
+          style={styles.row}
+        >
+          {avatarUri ? (
+            <Image source={{ uri: avatarUri }} style={styles.avatar} />
+          ) : (
+            <View style={[styles.avatar, styles.silhouette]}>
+              <Ionicons name="person" size={18} color="#9CA3AF" />
+            </View>
           )}
-        </View>
 
-        <View style={styles.right}>
-          {isUnread && <View style={styles.unread} />}
-          <Ionicons name="chevron-forward" size={18} color="#9CA3AF" />
-        </View>
-      </Pressable>
+          <View style={{ flex: 1 }}>
+            <Text style={styles.title} numberOfLines={1}>{item.title || "Chat"}</Text>
+            {!!item.lastMessage && (
+              <Text style={styles.sub} numberOfLines={1}>{item.lastMessage}</Text>
+            )}
+          </View>
+
+          <View style={styles.right}>
+            {isUnread && <View style={styles.unread} />}
+            <Ionicons name="chevron-forward" size={18} color="#9CA3AF" />
+          </View>
+        </Pressable>
+      </Swipeable>
     );
   };
 
@@ -108,6 +132,15 @@ const styles = StyleSheet.create({
     borderRadius: 12,
     backgroundColor: "#fff",
   },
+  delete: {
+    backgroundColor: "#EF4444",
+    justifyContent: "center",
+    alignItems: "center",
+    width: 72,
+    borderRadius: 12,
+    marginLeft: 8,
+  },
+  deleteText: { color: "#fff", fontWeight: "600", marginTop: 4 },
   avatar: { width: 44, height: 44, borderRadius: 22, backgroundColor: "#E5E7EB" },
   silhouette: { alignItems: "center", justifyContent: "center" },
   title: { fontWeight: "700", color: "#1F2937" },

--- a/mobile/app/_layout.tsx
+++ b/mobile/app/_layout.tsx
@@ -1,9 +1,12 @@
 import { Stack } from "expo-router";
+import { GestureHandlerRootView } from "react-native-gesture-handler";
 
 export default function RootLayout() {
   return (
-    <Stack screenOptions={{ headerShown: false }}>
-      {/* Auth screens + role groups live under here */}
-    </Stack>
+    <GestureHandlerRootView style={{ flex: 1 }}>
+      <Stack screenOptions={{ headerShown: false }}>
+        {/* Auth screens + role groups live under here */}
+      </Stack>
+    </GestureHandlerRootView>
   );
 }

--- a/mobile/src/lib/api.ts
+++ b/mobile/src/lib/api.ts
@@ -305,17 +305,16 @@ export async function deleteChat(chatId: number): Promise<void> {
     try {
       const token = useAuth.getState().token;
       if (token) {
-        const r = await fetch(`${API_BASE}/chats/${chatId}`, {
+        await fetch(`${API_BASE}/chats/${chatId}`, {
           method: "DELETE",
           headers: headers(token),
         });
-        if (r.ok) return;
       }
     } catch {}
   }
-  _chats = _chats.filter(c => c.id !== chatId);
+  _chats = _chats.filter((c) => c.id !== chatId);
   delete _messages[chatId];
-  _applications = _applications.filter(a => a.chatId !== chatId);
+  _applications = _applications.filter((a) => a.chatId !== chatId);
 }
 
 export async function applyToJob(jobId: number, workerId: number, workerName?: string): Promise<{ chatId: number }> {

--- a/mobile/src/lib/api.ts
+++ b/mobile/src/lib/api.ts
@@ -300,6 +300,24 @@ export async function sendMessage(chatId: number, body: string, username = "You"
   return Promise.resolve(msg);
 }
 
+export async function deleteChat(chatId: number): Promise<void> {
+  if (API_BASE) {
+    try {
+      const token = useAuth.getState().token;
+      if (token) {
+        const r = await fetch(`${API_BASE}/chats/${chatId}`, {
+          method: "DELETE",
+          headers: headers(token),
+        });
+        if (r.ok) return;
+      }
+    } catch {}
+  }
+  _chats = _chats.filter(c => c.id !== chatId);
+  delete _messages[chatId];
+  _applications = _applications.filter(a => a.chatId !== chatId);
+}
+
 export async function applyToJob(jobId: number, workerId: number, workerName?: string): Promise<{ chatId: number }> {
   let job = _jobs.find(j => j.id === jobId);
   if (API_BASE && !job) {

--- a/server/index.js
+++ b/server/index.js
@@ -360,6 +360,19 @@ app.get("/chats", auth, (req, res) => {
   res.json(chats);
 });
 
+app.delete("/chats/:id", auth, (req, res) => {
+  const chatId = Number(req.params.id);
+  const member = db
+    .prepare("SELECT 1 FROM chat_members WHERE chat_id = ? AND user_id = ?")
+    .get(chatId, req.user.sub);
+  if (!member) return res.status(403).json({ error: "Forbidden" });
+  db.prepare("DELETE FROM messages WHERE chat_id = ?").run(chatId);
+  db.prepare("DELETE FROM chat_members WHERE chat_id = ?").run(chatId);
+  db.prepare("DELETE FROM applications WHERE chat_id = ?").run(chatId);
+  db.prepare("DELETE FROM chats WHERE id = ?").run(chatId);
+  res.status(204).end();
+});
+
 app.get("/chats/:id/messages", auth, (req, res) => {
   const chatId = Number(req.params.id);
   const msgs = db.prepare(`


### PR DESCRIPTION
## Summary
- allow labourers to swipe chats to delete with confirmation
- allow managers to swipe chats to delete with confirmation
- add API helper for removing chats

## Testing
- ❌ `npm test`
- ✅ `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a63769c380832094cda4e265a0094b