### PR TITLE
Ensure labourers see manager names in chat headers

### DIFF
--- a/mobile/app/(labourer)/chats/[id].tsx
+++ b/mobile/app/(labourer)/chats/[id].tsx
@@ -41,7 +41,7 @@ const GO_BACK_TO = "/(labourer)/chats";
 export default function LabourerChatDetail() {
   const { id } = useLocalSearchParams<{ id: string }>();
   const chatId = Number(id);
-  const { user } = useAuth();
+  const { user, token } = useAuth();
   const myId = user?.id ?? 0;
   const myName = user?.username ?? "You";
   const profiles = useProfile((s) => s.profiles);
@@ -123,10 +123,11 @@ export default function LabourerChatDetail() {
       ensureProfile(
         otherId,
         nameFromMsg || titleName || (role === "manager" ? "Manager" : "Labourer"),
-        role
+        role,
+        token ?? undefined
       );
     }
-  }, [chat, myId, messages, ensureProfile]);
+  }, [chat, myId, messages, ensureProfile, token]);
 
   const onSend = useCallback(async () => {
     const body = input.trim();

--- a/mobile/app/(manager)/chats/[id].tsx
+++ b/mobile/app/(manager)/chats/[id].tsx
@@ -42,7 +42,7 @@ const GO_BACK_TO = "/(manager)/chats";
 export default function ManagerChatDetail() {
   const { id } = useLocalSearchParams<{ id: string }>();
   const chatId = Number(id);
-  const { user } = useAuth();
+  const { user, token } = useAuth();
   const myId = user?.id ?? 0;
   const myName = user?.username ?? "You";
   const profiles = useProfile((s) => s.profiles);
@@ -123,10 +123,11 @@ export default function ManagerChatDetail() {
       ensureProfile(
         otherId,
         nameFromMsg || (role === "manager" ? "Manager" : "Labourer"),
-        role
+        role,
+        token ?? undefined
       );
     }
-  }, [chat, myId, messages, ensureProfile]);
+  }, [chat, myId, messages, ensureProfile, token]);
 
   const onSend = useCallback(async () => {
     const body = input.trim();

--- a/mobile/src/store/useProfile.ts
+++ b/mobile/src/store/useProfile.ts
@@ -71,7 +71,19 @@ export const useProfile = create<State>()(
 
       ensureProfile: async (userId, name, role, token) => {
         const existing = get().profiles[userId];
-        if (existing) return existing;
+        if (existing) {
+          if (
+            name &&
+            existing.name !== name &&
+            (existing.name === "Manager" || existing.name === "Labourer")
+          ) {
+            const next = { ...existing, name };
+            set((s) => ({ profiles: { ...s.profiles, [userId]: next } }));
+            if (token) apiSaveProfile(next, token);
+            return next;
+          }
+          return existing;
+        }
         const remote = await apiFetchProfile(userId, token);
         if (remote) {
           set((s) => ({ profiles: { ...s.profiles, [userId]: remote } }));


### PR DESCRIPTION
## Summary
- Pass auth tokens when ensuring profiles in chat screens
- Replace placeholder "Manager"/"Labourer" names with real profile names once fetched

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a64ab694ec8320962116059185d6bb