### PR TITLE
Sync applied job state across views

### DIFF
--- a/mobile/app/(labourer)/jobs.tsx
+++ b/mobile/app/(labourer)/jobs.tsx
@@ -366,7 +366,7 @@ export default function Jobs() {
               {appliedChatId ? (
                 <>
                   <View style={[styles.btn, styles.btnMuted, { flex: 1 }]}>
-                    <Text style={[styles.btnMutedText, { textAlign: "center" }]}>Applied{appliedStatus ? ` • ${appliedStatus}` : ""}</Text>
+                    <Text style={[styles.btnMutedText, { textAlign: "center" }]}>Applied</Text>
                   </View>
                   <Pressable onPress={goToChat} style={[styles.btn, styles.btnPrimary, { flex: 1 }]}>
                     <Text style={styles.btnPrimaryText}>View chat</Text>

--- a/mobile/app/(labourer)/saved.tsx
+++ b/mobile/app/(labourer)/saved.tsx
@@ -7,6 +7,7 @@ import { useAuth } from "@src/store/useAuth";
 import { useNotifications } from "@src/store/useNotifications";
 import { Ionicons } from "@expo/vector-icons";
 import { router } from "expo-router";
+import { useAppliedJobs } from "@src/store/useAppliedJobs";
 
 function formatPay(pay?: string) {
   if (!pay) return "";
@@ -21,6 +22,7 @@ export default function SavedJobs() {
   const { savedJobIds, toggleSave } = useSaved();
   const { user } = useAuth();
   const { bump } = useNotifications();
+  const { setApplied } = useAppliedJobs();
 
   const [selected, setSelected] = useState<Job | null>(null);
   const [open, setOpen] = useState(false);
@@ -35,6 +37,7 @@ export default function SavedJobs() {
     try {
       const res = await applyToJob(selected.id, user.id, user.username);
       bump("manager", 1);
+      setApplied(selected.id, { chatId: res.chatId, status: "pending" });
       setOpen(false);
       router.push({ pathname: "/(labourer)/chats/[id]", params: { id: String(res.chatId) } });
     } catch (e: any) { Alert.alert("Error", e.message ?? "Failed to apply"); }

--- a/mobile/src/store/useAppliedJobs.ts
+++ b/mobile/src/store/useAppliedJobs.ts
@@ -1,0 +1,32 @@
+import { create } from "zustand";
+import { persist, createJSONStorage } from "zustand/middleware";
+import AsyncStorage from "@react-native-async-storage/async-storage";
+
+export type AppliedInfo = { chatId: number; status: "pending" | "accepted" | "declined" };
+
+interface AppliedState {
+  applied: Record<number, AppliedInfo>;
+  setApplied: (jobId: number, info: AppliedInfo) => void;
+  setMany: (infos: Record<number, AppliedInfo>) => void;
+  removeApplied: (jobId: number) => void;
+  clear: () => void;
+}
+
+export const useAppliedJobs = create<AppliedState>()(
+  persist(
+    (set) => ({
+      applied: {},
+      setApplied: (jobId, info) =>
+        set((s) => ({ applied: { ...s.applied, [jobId]: info } })),
+      setMany: (infos) =>
+        set((s) => ({ applied: { ...s.applied, ...infos } })),
+      removeApplied: (jobId) =>
+        set((s) => {
+          const { [jobId]: _removed, ...rest } = s.applied;
+          return { applied: rest };
+        }),
+      clear: () => set({ applied: {} }),
+    }),
+    { name: "bb-applied", storage: createJSONStorage(() => AsyncStorage), version: 1 }
+  )
+);


### PR DESCRIPTION
## Summary
- add persistent applied job store
- update job list, map, and saved screens to use shared applied job status

## Testing
- `npm test` (fails: Missing script)
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68a73dbc215c8320a80cbae3f9ad7f9f