### PR TITLE
Transform labourer jobs page into explore sections

### DIFF
--- a/mobile/app/(labourer)/jobs.tsx
+++ b/mobile/app/(labourer)/jobs.tsx
@@ -237,7 +237,7 @@ export default function Jobs() {
   };
 
   const renderSection = (title: string, data: Job[]) => (
-    <View style={{ marginTop: 20 }} key={title}>
+    <View key={title}>
       <Text style={styles.sectionTitle}>{title}</Text>
       <FlatList
         data={data}
@@ -245,7 +245,7 @@ export default function Jobs() {
         renderItem={renderCard}
         horizontal
         ItemSeparatorComponent={() => <View style={{ width: 12 }} />}
-        contentContainerStyle={{ paddingHorizontal: 12 }}
+        contentContainerStyle={{ paddingRight: 12 }}
         showsHorizontalScrollIndicator={false}
       />
     </View>
@@ -254,7 +254,7 @@ export default function Jobs() {
   return (
     <View style={{ flex: 1, backgroundColor: "#fff" }}>
       <TopBar />
-      <ScrollView contentContainerStyle={{ paddingBottom: 24 }}>
+      <ScrollView contentContainerStyle={{ paddingHorizontal: 12, paddingBottom: 24 }}>
         {renderSection("Featured Jobs", items)}
         {renderSection("Recommended for You", items)}
         {renderSection("Starting Soon", items)}
@@ -396,7 +396,7 @@ export default function Jobs() {
 
 const styles = StyleSheet.create({
   container: { flex: 1, backgroundColor: "#fff" },
-  sectionTitle: { fontWeight: "800", fontSize: 18, marginLeft: 12, marginBottom: 8, color: "#1F2937" },
+  sectionTitle: { color: "#6B7280", fontWeight: "800", marginTop: 6, marginBottom: 8 },
 
   card: {
     flexDirection: "row",

--- a/mobile/app/(labourer)/jobs.tsx
+++ b/mobile/app/(labourer)/jobs.tsx
@@ -217,22 +217,32 @@ export default function Jobs() {
       <Pressable style={styles.card} onPress={() => onPressCard(item)}>
         <Image source={{ uri: thumb }} style={styles.thumb} />
         <View style={{ flex: 1, gap: 2 }}>
-          <Text style={styles.title}>{item.title}</Text>
-          <Text style={styles.meta}>{item.site}</Text>
+          <Text style={styles.title} numberOfLines={1} ellipsizeMode="tail">
+            {item.title}
+          </Text>
+          <Text style={styles.meta} numberOfLines={1} ellipsizeMode="tail">
+            {item.site}
+          </Text>
           {!!item.location && (
             <View style={styles.row}>
               <Ionicons name="location-outline" size={16} color="#6B7280" />
-              <Text style={styles.meta}>{item.location}</Text>
+              <Text style={styles.meta} numberOfLines={1} ellipsizeMode="tail">
+                {item.location}
+              </Text>
             </View>
           )}
           <View style={styles.row}>
             <Ionicons name="calendar-outline" size={16} color="#6B7280" />
-            <Text style={styles.meta}>{item.when}</Text>
+            <Text style={styles.meta} numberOfLines={1} ellipsizeMode="tail">
+              {item.when}
+            </Text>
           </View>
           {!!pay && (
             <View style={styles.row}>
               <Ionicons name="cash-outline" size={16} color="#6B7280" />
-              <Text style={styles.meta}>{pay}</Text>
+              <Text style={styles.meta} numberOfLines={1} ellipsizeMode="tail">
+                {pay}
+              </Text>
             </View>
           )}
         </View>
@@ -444,7 +454,7 @@ const styles = StyleSheet.create({
 
   row: { flexDirection: "row", alignItems: "center", gap: 6, marginTop: 2 },
   title: { fontWeight: "700", fontSize: 16, marginBottom: 2, color: "#1F2937" },
-  meta: { color: "#555" },
+  meta: { color: "#555", flexShrink: 1 },
 
   saveBtn: {
     width: 40,

--- a/mobile/app/(labourer)/jobs.tsx
+++ b/mobile/app/(labourer)/jobs.tsx
@@ -1,5 +1,16 @@
 import React, { useEffect, useMemo, useState, useCallback } from "react";
-import { View, FlatList, Text, StyleSheet, Pressable, Image, Modal, ScrollView, Alert } from "react-native";
+import {
+  View,
+  FlatList,
+  Text,
+  StyleSheet,
+  Pressable,
+  Image,
+  Modal,
+  ScrollView,
+  Alert,
+  Dimensions,
+} from "react-native";
 import { listJobs, type Job, applyToJob, listChats, getApplicationForChat } from "@src/lib/api";
 import TopBar from "@src/components/TopBar";
 import { useSaved } from "@src/store/useSaved";
@@ -236,18 +247,28 @@ export default function Jobs() {
     );
   };
 
-  const renderSection = (title: string, data: Job[]) => (
+  const renderSection = (
+    title: string,
+    data: Job[],
+    showDivider = false,
+    emptyText?: string
+  ) => (
     <View key={title}>
+      {showDivider && <View style={styles.sectionDivider} />}
       <Text style={styles.sectionTitle}>{title}</Text>
-      <FlatList
-        data={data}
-        keyExtractor={(i) => String(i.id)}
-        renderItem={renderCard}
-        horizontal
-        ItemSeparatorComponent={() => <View style={{ width: 12 }} />}
-        contentContainerStyle={{ paddingRight: 12 }}
-        showsHorizontalScrollIndicator={false}
-      />
+      {data.length ? (
+        <FlatList
+          data={data}
+          keyExtractor={(i) => String(i.id)}
+          renderItem={renderCard}
+          horizontal
+          ItemSeparatorComponent={() => <View style={{ width: 12 }} />}
+          contentContainerStyle={{ paddingRight: 12 }}
+          showsHorizontalScrollIndicator={false}
+        />
+      ) : emptyText ? (
+        <Text style={styles.empty}>{emptyText}</Text>
+      ) : null}
     </View>
   );
 
@@ -256,10 +277,15 @@ export default function Jobs() {
       <TopBar />
       <ScrollView contentContainerStyle={{ paddingHorizontal: 12, paddingBottom: 24 }}>
         {renderSection("Featured Jobs", items)}
-        {renderSection("Recommended for You", items)}
-        {renderSection("Starting Soon", items)}
-        {renderSection("Nearby Jobs", items)}
-        {renderSection("Completed Jobs", completedJobs)}
+        {renderSection("Recommended for You", items, true)}
+        {renderSection("Starting Soon", items, true)}
+        {renderSection("Nearby Jobs", items, true)}
+        {renderSection(
+          "Completed Jobs",
+          completedJobs,
+          true,
+          "Once jobs complete, they'll appear here."
+        )}
       </ScrollView>
 
       {/* Details popup */}
@@ -394,11 +420,16 @@ export default function Jobs() {
   );
 }
 
+const CARD_WIDTH = Dimensions.get("window").width - 24;
+
 const styles = StyleSheet.create({
   container: { flex: 1, backgroundColor: "#fff" },
   sectionTitle: { color: "#6B7280", fontWeight: "800", marginTop: 6, marginBottom: 8 },
+  sectionDivider: { height: 1, backgroundColor: "#eee", marginVertical: 8 },
+  empty: { color: "#6B7280", marginBottom: 8 },
 
   card: {
+    width: CARD_WIDTH,
     flexDirection: "row",
     gap: 12,
     borderWidth: 1,
@@ -407,6 +438,7 @@ const styles = StyleSheet.create({
     padding: 12,
     backgroundColor: "#fff",
     alignItems: "center",
+    justifyContent: "space-between",
   },
   thumb: { width: 120, height: 88, borderRadius: 12, backgroundColor: "#eee" },
 

--- a/mobile/app/(manager)/projects.tsx
+++ b/mobile/app/(manager)/projects.tsx
@@ -1,7 +1,17 @@
 import { useEffect, useState, useCallback } from "react";
 import {
-  View, FlatList, StyleSheet, Text, Pressable, Modal, TextInput,
-  ScrollView, Alert, Image, Keyboard
+  View,
+  FlatList,
+  StyleSheet,
+  Text,
+  Pressable,
+  Modal,
+  TextInput,
+  ScrollView,
+  Alert,
+  Image,
+  Keyboard,
+  Dimensions,
 } from "react-native";
 import TopBar from "@src/components/TopBar";
 import { listManagerJobs, createJob, updateJob, deleteJob, type CreateJobInput, type Job } from "@src/lib/api";
@@ -293,8 +303,10 @@ export default function ManagerProjects() {
             data={upcoming}
             keyExtractor={(i) => String(i.id)}
             renderItem={({ item }) => <JobRow job={item} onPress={() => openDetails(item)} />}
-            ItemSeparatorComponent={() => <View style={styles.sep} />}
-            scrollEnabled={false}
+            horizontal
+            ItemSeparatorComponent={() => <View style={{ width: 12 }} />}
+            contentContainerStyle={{ paddingRight: 12 }}
+            showsHorizontalScrollIndicator={false}
           />
         ) : (
           <Text style={styles.empty}>You have no upcoming jobs.</Text>
@@ -308,8 +320,10 @@ export default function ManagerProjects() {
             data={current}
             keyExtractor={(i) => String(i.id)}
             renderItem={({ item }) => <JobRow job={item} onPress={() => openDetails(item)} />}
-            ItemSeparatorComponent={() => <View style={styles.sep} />}
-            scrollEnabled={false}
+            horizontal
+            ItemSeparatorComponent={() => <View style={{ width: 12 }} />}
+            contentContainerStyle={{ paddingRight: 12 }}
+            showsHorizontalScrollIndicator={false}
           />
         ) : (
           <Text style={styles.empty}>You have no current jobs.</Text>
@@ -323,8 +337,10 @@ export default function ManagerProjects() {
             data={previous}
             keyExtractor={(i) => String(i.id)}
             renderItem={({ item }) => <JobRow job={item} onPress={() => openDetails(item)} />}
-            ItemSeparatorComponent={() => <View style={styles.sep} />}
-            scrollEnabled={false}
+            horizontal
+            ItemSeparatorComponent={() => <View style={{ width: 12 }} />}
+            contentContainerStyle={{ paddingRight: 12 }}
+            showsHorizontalScrollIndicator={false}
           />
         ) : (
           <Text style={styles.empty}>Once jobs complete, they’ll appear here.</Text>
@@ -563,11 +579,24 @@ function JobRow({ job, onPress }: { job: Job; onPress: () => void }) {
     <Pressable style={styles.card} onPress={onPress}>
       <Image source={{ uri: thumb }} style={styles.thumb} />
       <View style={{ flex:1, gap:2 }}>
-        <Text style={styles.jobTitle}>{job.title}</Text>
-        <Text style={styles.meta}>{job.site}</Text>
-        {!!job.location && (<View style={styles.row}><Ionicons name="location-outline" size={16} color="#6B7280" /><Text style={styles.meta}>{job.location}</Text></View>)}
-        <View style={styles.row}><Ionicons name="calendar-outline" size={16} color="#6B7280" /><Text style={styles.meta}>{job.when}</Text></View>
-        {!!job.payRate && (<View style={styles.row}><Ionicons name="cash-outline" size={16} color="#6B7280" /><Text style={styles.meta}>{formatPay(job.payRate)}</Text></View>)}
+        <Text style={styles.jobTitle} numberOfLines={1} ellipsizeMode="tail">{job.title}</Text>
+        <Text style={styles.meta} numberOfLines={1} ellipsizeMode="tail">{job.site}</Text>
+        {!!job.location && (
+          <View style={styles.row}>
+            <Ionicons name="location-outline" size={16} color="#6B7280" />
+            <Text style={styles.meta} numberOfLines={1} ellipsizeMode="tail">{job.location}</Text>
+          </View>
+        )}
+        <View style={styles.row}>
+          <Ionicons name="calendar-outline" size={16} color="#6B7280" />
+          <Text style={styles.meta} numberOfLines={1} ellipsizeMode="tail">{job.when}</Text>
+        </View>
+        {!!job.payRate && (
+          <View style={styles.row}>
+            <Ionicons name="cash-outline" size={16} color="#6B7280" />
+            <Text style={styles.meta} numberOfLines={1} ellipsizeMode="tail">{formatPay(job.payRate)}</Text>
+          </View>
+        )}
       </View>
       <Ionicons name="chevron-forward" size={20} color="#9CA3AF" />
     </Pressable>
@@ -596,6 +625,8 @@ function composeAddress(r: Location.LocationGeocodedAddress): string {
   return bits.filter(Boolean).join(", ");
 }
 
+const CARD_WIDTH = Dimensions.get("window").width - 24;
+
 const styles = StyleSheet.create({
   container:{ flex:1, backgroundColor:"#fff" },
   headerRow:{ paddingHorizontal:12, paddingTop:6, paddingBottom:10, flexDirection:"row", alignItems:"center", justifyContent:"space-between" },
@@ -605,14 +636,13 @@ const styles = StyleSheet.create({
 
   sectionTitle:{ color:"#6B7280", fontWeight:"800", marginTop:6, marginBottom:8 },
   sectionDivider:{ height:1, backgroundColor:"#eee", marginVertical:8 },
-  sep:{ height:12 },
   empty:{ color:"#6B7280", marginBottom:8 },
 
-  card:{ borderWidth:1, borderColor:"#eee", backgroundColor:"#fff", borderRadius:12, padding:12, flexDirection:"row", alignItems:"center", gap:12, justifyContent:"space-between" },
+  card:{ width: CARD_WIDTH, borderWidth:1, borderColor:"#eee", backgroundColor:"#fff", borderRadius:12, padding:12, flexDirection:"row", alignItems:"center", gap:12, justifyContent:"space-between" },
   thumb:{ width:120, height:88, borderRadius:12, backgroundColor:"#eee" },
   row:{ flexDirection:"row", alignItems:"center", gap:6, marginTop:2 },
   jobTitle:{ fontWeight:"700", fontSize:16, marginBottom:2, color:"#1F2937" },
-  meta:{ color:"#6B7280" },
+  meta:{ color:"#6B7280", flexShrink:1 },
 
   modalWrap:{ flex:1, backgroundColor:"#fff" },
   modalHeader:{ paddingHorizontal:12, paddingTop:14, paddingBottom:8, borderBottomWidth:1, borderColor:"#eee", flexDirection:"row", alignItems:"center", justifyContent:"space-between", gap:10 },


### PR DESCRIPTION
## Summary
- replace filter chips with explore layout
- add horizontal job rows: Featured Jobs, Recommended for You, Starting Soon, Nearby Jobs, Completed Jobs

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a74cad0be48320adf97aacc0163943