### PR TITLE
Upload job images after creation

### DIFF
--- a/mobile/app/(manager)/projects.tsx
+++ b/mobile/app/(manager)/projects.tsx
@@ -193,9 +193,13 @@ export default function ManagerProjects() {
     Alert.alert("Delete job", "Are you sure you want to delete this listing?", [
       { text:"Cancel", style:"cancel" },
       { text:"Delete", style:"destructive", onPress: async () => {
-        await deleteJob(selected.id, token || undefined);
-        setDetailsOpen(false);
-        await refresh();
+        try {
+          await deleteJob(selected.id, token || undefined);
+          setDetailsOpen(false);
+          await refresh();
+        } catch (e:any) {
+          Alert.alert("Error", e.message || "Failed to delete job");
+        }
       } }
     ]);
   };

--- a/server/package.json
+++ b/server/package.json
@@ -6,6 +6,7 @@
     "start": "node index.js"
   },
   "dependencies": {
+    "@azure/storage-blob": "^12.28.0",
     "bcryptjs": "^2.4.3",
     "better-sqlite3": "^9.4.0",
     "cors": "^2.8.5",
@@ -13,6 +14,7 @@
     "express": "^4.21.2",
     "jsonwebtoken": "^9.0.2",
     "mongoose": "^8.17.1",
+    "multer": "^2.0.2",
     "socket.io": "^4.8.1"
   }
 }


### PR DESCRIPTION
## Summary
- Upload local image to `/jobs/:id/image` after creating a job
- Replace local `imageUri` with blob URL returned from server
- Remove job images from blob storage when jobs are deleted
- Throw errors when job creation or image upload fails so jobs aren't silently local-only
- Show an error alert if deleting a job fails

## Testing
- `npm test --prefix mobile` *(fails: Missing script "test")*
- `npm run lint --prefix mobile`
- `npm test --prefix server` *(fails: Missing script "test")*
- `node server/index.js`


------
https://chatgpt.com/codex/tasks/task_e_68a8b6c1d55c8320a4a036157900b4a5