### PR TITLE
Add Construction AI chat with web search

### DIFF
--- a/mobile/app/(labourer)/chats.tsx
+++ b/mobile/app/(labourer)/chats.tsx
@@ -31,8 +31,13 @@ export default function Chats() {
         text: "Delete",
         style: "destructive",
         onPress: async () => {
-          setItems((prev) => prev.filter((c) => c.id !== id));
-          await deleteChat(id);
+          if (id === 0) {
+            await deleteChat(0);
+            load();
+          } else {
+            setItems((prev) => prev.filter((c) => c.id !== id));
+            await deleteChat(id);
+          }
         },
       },
     ]);
@@ -72,7 +77,11 @@ export default function Chats() {
           onPress={() => router.push(`/(labourer)/chats/${item.id}`)}
           style={styles.row}
         >
-          {avatarUri ? (
+          {item.id === 0 ? (
+            <View style={[styles.avatar, styles.silhouette]}>
+              <Ionicons name="construct" size={18} color="#9CA3AF" />
+            </View>
+          ) : avatarUri ? (
             <Image source={{ uri: avatarUri }} style={styles.avatar} />
           ) : (
             <View style={[styles.avatar, styles.silhouette]}>

--- a/mobile/app/(labourer)/chats/[id].tsx
+++ b/mobile/app/(labourer)/chats/[id].tsx
@@ -62,7 +62,7 @@ export default function LabourerChatDetail() {
     const [data, meta, app] = await Promise.all([
       listMessages(id),
       getChat(id),
-      getApplicationForChat(id),
+      id === 0 ? Promise.resolve(null) : getApplicationForChat(id),
     ]);
     if (id !== chatId) return;
     setMessages(Array.isArray(data) ? data : []);
@@ -88,6 +88,7 @@ export default function LabourerChatDetail() {
   }, [messages.length]);
 
   useEffect(() => {
+    if (chatId === 0) return;
     const s = getSocket();
     if (s) {
       s.emit("join", { chatId });
@@ -107,7 +108,7 @@ export default function LabourerChatDetail() {
 
   // Load the other party's profile so we can display their name
   useEffect(() => {
-    if (!chat || !token) return;
+    if (!chat || !token || chatId === 0) return;
     const otherId = myId === chat.managerId ? chat.workerId : chat.managerId;
     if (!otherId) return;
     const existing = profiles[otherId];
@@ -116,7 +117,7 @@ export default function LabourerChatDetail() {
       const remote = await fetchProfile(otherId, token);
       if (remote) upsertProfile(remote);
     })();
-  }, [chat, myId, token, profiles, upsertProfile]);
+  }, [chat, chatId, myId, token, profiles, upsertProfile]);
 
   const onSend = useCallback(async () => {
     const body = input.trim();
@@ -135,8 +136,10 @@ export default function LabourerChatDetail() {
 
     try {
       await sendMessage(chatId, body, myName);
-      // Notify Manager for new message
-      useNotifications.getState().bump("manager");
+      if (chatId !== 0) {
+        // Notify Manager for new message
+        useNotifications.getState().bump("manager");
+      }
       await load();
     } catch {
       setMessages((prev) => prev.filter((m) => m.id !== optimistic.id));
@@ -218,6 +221,7 @@ export default function LabourerChatDetail() {
   const otherProfile = otherPartyId ? profiles[otherPartyId] : undefined;
 
   const otherPartyName = useMemo(() => {
+    if (chatId === 0) return "Construction AI";
     const name = otherProfile?.name;
     if (name && name !== "Manager" && name !== "Labourer") return name;
     const msgName = messages.find(
@@ -227,7 +231,7 @@ export default function LabourerChatDetail() {
     const title = chat?.title;
     if (title && !title.startsWith("Job:")) return title;
     return "Chat";
-  }, [otherProfile, messages, myId, chat]);
+  }, [chatId, otherProfile, messages, myId, chat]);
 
   const lastByUser = useMemo(() => {
     const map: Record<number, number> = {};
@@ -258,7 +262,11 @@ export default function LabourerChatDetail() {
       <Image source={{ uri: avatarUri }} style={styles.avatar} />
     ) : (
       <View style={[styles.avatar, styles.silhouette]}>
-        <Ionicons name="person" size={18} color="#9CA3AF" />
+        <Ionicons
+          name={item.user_id === 0 ? "construct" : "person"}
+          size={18}
+          color="#9CA3AF"
+        />
       </View>
     );
 
@@ -307,7 +315,11 @@ export default function LabourerChatDetail() {
                   <Ionicons name="person" size={18} color="#9CA3AF" />
                 </View>
               )
-            ) : null}
+            ) : (
+              <View style={[styles.avatar, styles.silhouette]}>
+                <Ionicons name="construct" size={18} color="#9CA3AF" />
+              </View>
+            )}
             <Text style={styles.headerTitle} numberOfLines={1}>
               {otherPartyName}
             </Text>

--- a/mobile/app/(manager)/chats.tsx
+++ b/mobile/app/(manager)/chats.tsx
@@ -31,8 +31,13 @@ export default function Chats() {
         text: "Delete",
         style: "destructive",
         onPress: async () => {
-          setItems((prev) => prev.filter((c) => c.id !== id));
-          await deleteChat(id);
+          if (id === 0) {
+            await deleteChat(0);
+            load();
+          } else {
+            setItems((prev) => prev.filter((c) => c.id !== id));
+            await deleteChat(id);
+          }
         },
       },
     ]);
@@ -72,7 +77,11 @@ export default function Chats() {
           onPress={() => router.push(`/(manager)/chats/${item.id}`)}
           style={styles.row}
         >
-          {avatarUri ? (
+          {item.id === 0 ? (
+            <View style={[styles.avatar, styles.silhouette]}>
+              <Ionicons name="construct" size={18} color="#9CA3AF" />
+            </View>
+          ) : avatarUri ? (
             <Image source={{ uri: avatarUri }} style={styles.avatar} />
           ) : (
             <View style={[styles.avatar, styles.silhouette]}>

--- a/server/package.json
+++ b/server/package.json
@@ -12,6 +12,7 @@
     "cors": "^2.8.5",
     "dotenv": "^16.6.1",
     "express": "^4.21.2",
+    "openai": "^4.0.0",
     "jsonwebtoken": "^9.0.2",
     "mongoose": "^8.17.1",
     "multer": "^2.0.2",


### PR DESCRIPTION
## Summary
- add OpenAI and Google search powered Construction AI chat stored in SQLite
- surface pinned "Construction AI" chat for managers and labourers
- allow clearing AI conversation without removing the chat entry

## Testing
- `npm --prefix mobile test` *(fails: Missing script)*
- `npm --prefix mobile run lint`
- `npm --prefix server test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68ab506df6448320a7759b333841efdf