### PR TITLE
feat(manager): show create task in bottom sheet

### DIFF
--- a/mobile/app/(manager)/create-task.tsx
+++ b/mobile/app/(manager)/create-task.tsx
@@ -1,20 +1,43 @@
-import React, { useState } from "react";
-import { View, Text, TextInput, Pressable, StyleSheet, Alert } from "react-native";
+import React, { useEffect, useState } from "react";
+import { View, Text, TextInput, Pressable, StyleSheet, Alert, Picker } from "react-native";
 import TopBar from "@src/components/TopBar";
 import { Colors } from "@src/theme/tokens";
+import { listManagerJobs, type Job } from "@src/lib/api";
+import { useAuth } from "@src/store/useAuth";
 
 export function CreateTaskForm({ onSubmit }: { onSubmit?: () => void }) {
+  const [jobId, setJobId] = useState<string>("");
+  const [jobs, setJobs] = useState<Job[]>([]);
   const [title, setTitle] = useState("");
   const [dueDate, setDueDate] = useState("");
   const [assignee, setAssignee] = useState("");
+  const { user } = useAuth();
+
+  useEffect(() => {
+    if (user?.id) {
+      listManagerJobs(user.id).then(setJobs);
+    }
+  }, [user?.id]);
 
   const submit = () => {
-    Alert.alert("Task info", `Title: ${title}\nDue date: ${dueDate}\nAssignee: ${assignee}`);
+    const jobTitle = jobs.find((j) => String(j.id) === jobId)?.title ?? "";
+    Alert.alert(
+      "Task info",
+      `Job: ${jobTitle}\nTitle: ${title}\nDue date: ${dueDate}\nAssignee: ${assignee}`
+    );
     onSubmit?.();
   };
 
   return (
     <View>
+      <View style={styles.input}>
+        <Picker selectedValue={jobId} onValueChange={(v) => setJobId(String(v))}>
+          <Picker.Item label="Select job" value="" />
+          {jobs.map((j) => (
+            <Picker.Item label={j.title} value={String(j.id)} key={j.id} />
+          ))}
+        </Picker>
+      </View>
       <TextInput
         placeholder="Task title"
         value={title}

--- a/mobile/app/(manager)/create-task.tsx
+++ b/mobile/app/(manager)/create-task.tsx
@@ -1,44 +1,23 @@
-import React, { useEffect, useState } from "react";
+import React, { useState } from "react";
 import { View, Text, TextInput, Pressable, StyleSheet, Alert } from "react-native";
-import { Picker } from "@react-native-picker/picker";
 import TopBar from "@src/components/TopBar";
 import { Colors } from "@src/theme/tokens";
-import { listManagerJobs, type Job } from "@src/lib/api";
-import { useAuth } from "@src/store/useAuth";
 
 export function CreateTaskForm({ onSubmit }: { onSubmit?: () => void }) {
-  const [jobId, setJobId] = useState<string>("");
-  const [jobs, setJobs] = useState<Job[]>([]);
   const [title, setTitle] = useState("");
   const [dueDate, setDueDate] = useState("");
   const [assignee, setAssignee] = useState("");
-  const { user } = useAuth();
-
-  useEffect(() => {
-    if (user?.id) {
-      listManagerJobs(user.id).then(setJobs);
-    }
-  }, [user?.id]);
 
   const submit = () => {
-    const jobTitle = jobs.find((j) => String(j.id) === jobId)?.title ?? "";
     Alert.alert(
       "Task info",
-      `Job: ${jobTitle}\nTitle: ${title}\nDue date: ${dueDate}\nAssignee: ${assignee}`
+      `Title: ${title}\nDue date: ${dueDate}\nAssignee: ${assignee}`
     );
     onSubmit?.();
   };
 
   return (
     <View>
-      <View style={styles.input}>
-        <Picker selectedValue={jobId} onValueChange={(v) => setJobId(String(v))}>
-          <Picker.Item label="Select job" value="" />
-          {jobs.map((j) => (
-            <Picker.Item label={j.title} value={String(j.id)} key={j.id} />
-          ))}
-        </Picker>
-      </View>
       <TextInput
         placeholder="Task title"
         value={title}

--- a/mobile/app/(manager)/create-task.tsx
+++ b/mobile/app/(manager)/create-task.tsx
@@ -3,41 +3,50 @@ import { View, Text, TextInput, Pressable, StyleSheet, Alert } from "react-nativ
 import TopBar from "@src/components/TopBar";
 import { Colors } from "@src/theme/tokens";
 
+export function CreateTaskForm({ onSubmit }: { onSubmit?: () => void }) {
+  const [title, setTitle] = useState("");
+  const [dueDate, setDueDate] = useState("");
+  const [assignee, setAssignee] = useState("");
+
+  const submit = () => {
+    Alert.alert("Task info", `Title: ${title}\nDue date: ${dueDate}\nAssignee: ${assignee}`);
+    onSubmit?.();
+  };
+
+  return (
+    <View>
+      <TextInput
+        placeholder="Task title"
+        value={title}
+        onChangeText={setTitle}
+        style={styles.input}
+      />
+      <TextInput
+        placeholder="Due date"
+        value={dueDate}
+        onChangeText={setDueDate}
+        style={styles.input}
+      />
+      <TextInput
+        placeholder="Assignee"
+        value={assignee}
+        onChangeText={setAssignee}
+        style={styles.input}
+      />
+      <Pressable onPress={submit} style={styles.submitBtn} accessibilityRole="button">
+        <Text style={styles.submitText}>Create Task</Text>
+      </Pressable>
+    </View>
+  );
+}
+
 export default function CreateTask() {
-
-    const [title, setTitle] = useState("");
-    const [dueDate, setDueDate] = useState("");
-    const [assignee, setAssignee] = useState("");
-
-    const onSubmit = () => {
-      Alert.alert("Task info", `Title: ${title}\nDue date: ${dueDate}\nAssignee: ${assignee}`);
-    };
   return (
     <View style={styles.container}>
       <TopBar />
       <View style={styles.content}>
         <Text style={styles.title}>Create Task</Text>
-                <TextInput
-          placeholder="Task title"
-          value={title}
-          onChangeText={setTitle}
-          style={styles.input}
-        />
-        <TextInput
-          placeholder="Due date"
-          value={dueDate}
-          onChangeText={setDueDate}
-          style={styles.input}
-        />
-        <TextInput
-          placeholder="Assignee"
-          value={assignee}
-          onChangeText={setAssignee}
-          style={styles.input}
-        />
-        <Pressable onPress={onSubmit} style={styles.submitBtn} accessibilityRole="button">
-          <Text style={styles.submitText}>Create Task</Text>
-        </Pressable>
+        <CreateTaskForm />
       </View>
     </View>
   );

--- a/mobile/app/(manager)/create-task.tsx
+++ b/mobile/app/(manager)/create-task.tsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useState } from "react";
-import { View, Text, TextInput, Pressable, StyleSheet, Alert, Picker } from "react-native";
+import { View, Text, TextInput, Pressable, StyleSheet, Alert } from "react-native";
+import { Picker } from "@react-native-picker/picker";
 import TopBar from "@src/components/TopBar";
 import { Colors } from "@src/theme/tokens";
 import { listManagerJobs, type Job } from "@src/lib/api";

--- a/mobile/app/(manager)/team.tsx
+++ b/mobile/app/(manager)/team.tsx
@@ -1,13 +1,14 @@
 import { useEffect, useState } from "react";
-import { View, FlatList, Text, StyleSheet, Pressable} from "react-native";
+import { View, FlatList, Text, StyleSheet, Pressable, Modal, ScrollView } from "react-native";
 import { listTeam } from "@src/lib/api";
 import TopBar from "@src/components/TopBar";
 import { Ionicons } from "@expo/vector-icons";
-import { router } from "expo-router";
 import { Colors } from "@src/theme/tokens";
+import { CreateTaskForm } from "./create-task";
 
 export default function ManagerTeam() {
   const [people, setPeople] = useState<any[]>([]);
+  const [taskOpen, setTaskOpen] = useState(false);
   useEffect(() => { listTeam().then(setPeople); }, []);
 
   return (
@@ -15,7 +16,7 @@ export default function ManagerTeam() {
       <TopBar />
       <View style={styles.headerRow}>
         <Text style={styles.headerTitle}>My Team</Text>
-        <Pressable style={styles.createBtn} onPress={() => router.push("/(manager)/create-task")}> 
+        <Pressable style={styles.createBtn} onPress={() => setTaskOpen(true)}>
           <Ionicons name="add" size={18} />
           <Text style={styles.createText}>Create task</Text>
         </Pressable>
@@ -42,6 +43,26 @@ export default function ManagerTeam() {
         )}
         ItemSeparatorComponent={() => <View style={styles.sep} />}
       />
+
+      <Modal
+        visible={taskOpen}
+        animationType="slide"
+        presentationStyle="pageSheet"
+        onRequestClose={() => setTaskOpen(false)}
+      >
+        <View style={styles.modalWrap}>
+          <View style={styles.modalHeader}>
+            <Pressable onPress={() => setTaskOpen(false)} style={styles.modalClose}>
+              <Ionicons name="close" size={22} />
+            </Pressable>
+            <Text style={styles.modalTitle}>Create Task</Text>
+            <View style={{ width:34 }} />
+          </View>
+          <ScrollView contentContainerStyle={{ padding:16 }}>
+            <CreateTaskForm onSubmit={() => setTaskOpen(false)} />
+          </ScrollView>
+        </View>
+      </Modal>
     </View>
   );
 }
@@ -61,5 +82,9 @@ const styles = StyleSheet.create({
   status:{ textTransform:"capitalize" },
   online:{ color:"#16a34a" },
   offline:{ color:"#9ca3af" },
-  sep:{ height:1, backgroundColor:"#f0f0f0", marginHorizontal:12 }
+  sep:{ height:1, backgroundColor:"#f0f0f0", marginHorizontal:12 },
+  modalWrap:{ flex:1, backgroundColor:"#fff" },
+  modalHeader:{ paddingHorizontal:12, paddingTop:14, paddingBottom:8, borderBottomWidth:1, borderColor:"#eee", flexDirection:"row", alignItems:"center", justifyContent:"space-between", gap:10 },
+  modalClose:{ padding:6 },
+  modalTitle:{ fontWeight:"800", fontSize:18, color:"#1F2937" }
 });

--- a/mobile/package.json
+++ b/mobile/package.json
@@ -20,6 +20,7 @@
   "dependencies": {
     "@expo/vector-icons": "^14.1.0",
     "@react-native-async-storage/async-storage": "2.1.2",
+    "@react-native-picker/picker": "^2.11.1",
     "@react-navigation/bottom-tabs": "^7.3.10",
     "@react-navigation/elements": "^2.3.8",
     "@react-navigation/native": "^7.1.6",

--- a/mobile/package.json
+++ b/mobile/package.json
@@ -20,7 +20,6 @@
   "dependencies": {
     "@expo/vector-icons": "^14.1.0",
     "@react-native-async-storage/async-storage": "2.1.2",
-    "@react-native-picker/picker": "^2.11.1",
     "@react-navigation/bottom-tabs": "^7.3.10",
     "@react-navigation/elements": "^2.3.8",
     "@react-navigation/native": "^7.1.6",


### PR DESCRIPTION
## Summary
- slide up task creation form on team screen instead of routing
- extract `CreateTaskForm` for reuse

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68adc29ddaec8320820c75e1f40a0a8b