### PR TITLE
feat(chat): enable profile viewing

### DIFF
--- a/mobile/app/(labourer)/chats/[id].tsx
+++ b/mobile/app/(labourer)/chats/[id].tsx
@@ -268,9 +268,11 @@ export default function LabourerChatDetail() {
         userId: String(otherPartyId),
         from: "chat",
         role: "manager",
+        chatId: String(chatId),
+        viewer: "labourer",
       },
     });
-  }, [otherPartyId]);
+  }, [otherPartyId, chatId]);
 
   const lastByUser = useMemo(() => {
     const map: Record<number, number> = {};

--- a/mobile/app/(labourer)/chats/[id].tsx
+++ b/mobile/app/(labourer)/chats/[id].tsx
@@ -260,6 +260,18 @@ export default function LabourerChatDetail() {
     return "Chat";
   }, [chatId, otherProfile, messages, myId, chat]);
 
+  const goToProfile = useCallback(() => {
+    if (!otherPartyId) return;
+    router.push({
+      pathname: "/(labourer)/profileDetails",
+      params: {
+        userId: String(otherPartyId),
+        from: "chat",
+        role: "manager",
+      },
+    });
+  }, [otherPartyId]);
+
   const lastByUser = useMemo(() => {
     const map: Record<number, number> = {};
     for (let i = messages.length - 1; i >= 0; i--) {
@@ -400,22 +412,31 @@ export default function LabourerChatDetail() {
               <Text style={styles.headerBack}>‹</Text>
             </Pressable>
             {otherPartyId ? (
-              otherProfile?.avatarUri ? (
-                <Image source={{ uri: otherProfile.avatarUri }} style={styles.avatar} />
-              ) : (
-                <View style={[styles.avatar, styles.silhouette]}>
-                  <Ionicons name="person" size={18} color="#9CA3AF" />
-                </View>
-              )
+              <Pressable onPress={goToProfile} hitSlop={12}>
+                {otherProfile?.avatarUri ? (
+                  <Image source={{ uri: otherProfile.avatarUri }} style={styles.avatar} />
+                ) : (
+                  <View style={[styles.avatar, styles.silhouette]}>
+                    <Ionicons name="person" size={18} color="#9CA3AF" />
+                  </View>
+                )}
+              </Pressable>
             ) : (
               <Image
                 source={require("../../../assets/images/ConstructionAI.png")}
                 style={styles.avatar}
               />
             )}
-            <Text style={styles.headerTitle} numberOfLines={1}>
-              {otherPartyName}
-            </Text>
+            <Pressable
+              onPress={goToProfile}
+              disabled={!otherPartyId}
+              style={{ flex: 1 }}
+              hitSlop={12}
+            >
+              <Text style={styles.headerTitle} numberOfLines={1}>
+                {otherPartyName}
+              </Text>
+            </Pressable>
             <View style={{ width: 18 }} />
           </View>
 

--- a/mobile/app/(labourer)/profileDetails.tsx
+++ b/mobile/app/(labourer)/profileDetails.tsx
@@ -30,8 +30,6 @@ export default function LabourerProfileDetails() {
     jobId?: string;
     from?: string;
     role?: string;
-    chatId?: string;
-    viewer?: string;
   }>();
   const viewUserId = params.userId
     ? parseInt(Array.isArray(params.userId) ? params.userId[0] : params.userId, 10)
@@ -49,14 +47,6 @@ export default function LabourerProfileDetails() {
       ? params.role[0]
       : params.role
     : "manager") as RoleKey;
-  const chatId = params.chatId
-    ? parseInt(Array.isArray(params.chatId) ? params.chatId[0] : params.chatId, 10)
-    : undefined;
-  const viewer = (params.viewer
-    ? Array.isArray(params.viewer)
-      ? params.viewer[0]
-      : params.viewer
-    : undefined) as RoleKey | undefined;
   const isOwn = viewUserId === authUserId;
 
   const profiles = useProfile((s) => s.profiles);
@@ -209,12 +199,8 @@ export default function LabourerProfileDetails() {
                 if (backJobId) {
                   const dest = from === "jobs" ? "/(labourer)/jobs" : "/(labourer)/map";
                   router.replace({ pathname: dest, params: { jobId: String(backJobId) } });
-                } else if (from === "chat" && chatId != null) {
-                  const dest =
-                    viewer === "manager"
-                      ? "/(manager)/chats/[id]"
-                      : "/(labourer)/chats/[id]";
-                  router.replace({ pathname: dest, params: { id: String(chatId) } });
+                } else if (from === "chat") {
+                  router.back();
                 } else {
                   router.replace(BACK_TO);
                 }

--- a/mobile/app/(labourer)/profileDetails.tsx
+++ b/mobile/app/(labourer)/profileDetails.tsx
@@ -30,6 +30,8 @@ export default function LabourerProfileDetails() {
     jobId?: string;
     from?: string;
     role?: string;
+    chatId?: string;
+    viewer?: string;
   }>();
   const viewUserId = params.userId
     ? parseInt(Array.isArray(params.userId) ? params.userId[0] : params.userId, 10)
@@ -47,6 +49,14 @@ export default function LabourerProfileDetails() {
       ? params.role[0]
       : params.role
     : "manager") as RoleKey;
+  const chatId = params.chatId
+    ? parseInt(Array.isArray(params.chatId) ? params.chatId[0] : params.chatId, 10)
+    : undefined;
+  const viewer = (params.viewer
+    ? Array.isArray(params.viewer)
+      ? params.viewer[0]
+      : params.viewer
+    : undefined) as RoleKey | undefined;
   const isOwn = viewUserId === authUserId;
 
   const profiles = useProfile((s) => s.profiles);
@@ -199,8 +209,12 @@ export default function LabourerProfileDetails() {
                 if (backJobId) {
                   const dest = from === "jobs" ? "/(labourer)/jobs" : "/(labourer)/map";
                   router.replace({ pathname: dest, params: { jobId: String(backJobId) } });
-                } else if (from === "chat") {
-                  router.back();
+                } else if (from === "chat" && chatId != null) {
+                  const dest =
+                    viewer === "manager"
+                      ? "/(manager)/chats/[id]"
+                      : "/(labourer)/chats/[id]";
+                  router.replace({ pathname: dest, params: { id: String(chatId) } });
                 } else {
                   router.replace(BACK_TO);
                 }

--- a/mobile/app/(manager)/chats/[id].tsx
+++ b/mobile/app/(manager)/chats/[id].tsx
@@ -279,6 +279,18 @@ export default function ManagerChatDetail() {
     return "Chat";
   }, [chatId, otherProfile, messages, myId, chat]);
 
+  const goToProfile = useCallback(() => {
+    if (!otherPartyId) return;
+    router.push({
+      pathname: "/(labourer)/profileDetails",
+      params: {
+        userId: String(otherPartyId),
+        from: "chat",
+        role: "labourer",
+      },
+    });
+  }, [otherPartyId]);
+
   const lastByUser = useMemo(() => {
     const map: Record<number, number> = {};
     for (let i = messages.length - 1; i >= 0; i--) {
@@ -419,22 +431,31 @@ export default function ManagerChatDetail() {
               <Text style={styles.headerBack}>‹</Text>
             </Pressable>
             {otherPartyId ? (
-              otherProfile?.avatarUri ? (
-                <Image source={{ uri: otherProfile.avatarUri }} style={styles.avatar} />
-              ) : (
-                <View style={[styles.avatar, styles.silhouette]}>
-                  <Ionicons name="person" size={18} color="#9CA3AF" />
-                </View>
-              )
+              <Pressable onPress={goToProfile} hitSlop={12}>
+                {otherProfile?.avatarUri ? (
+                  <Image source={{ uri: otherProfile.avatarUri }} style={styles.avatar} />
+                ) : (
+                  <View style={[styles.avatar, styles.silhouette]}>
+                    <Ionicons name="person" size={18} color="#9CA3AF" />
+                  </View>
+                )}
+              </Pressable>
             ) : (
               <Image
                 source={require("../../../assets/images/ConstructionAI.png")}
                 style={styles.avatar}
               />
             )}
-            <Text style={styles.headerTitle} numberOfLines={1}>
-              {otherPartyName}
-            </Text>
+            <Pressable
+              onPress={goToProfile}
+              disabled={!otherPartyId}
+              style={{ flex: 1 }}
+              hitSlop={12}
+            >
+              <Text style={styles.headerTitle} numberOfLines={1}>
+                {otherPartyName}
+              </Text>
+            </Pressable>
             <View style={{ width: 18 }} />
           </View>
 

--- a/mobile/app/(manager)/chats/[id].tsx
+++ b/mobile/app/(manager)/chats/[id].tsx
@@ -287,9 +287,11 @@ export default function ManagerChatDetail() {
         userId: String(otherPartyId),
         from: "chat",
         role: "labourer",
+        chatId: String(chatId),
+        viewer: "manager",
       },
     });
-  }, [otherPartyId]);
+  }, [otherPartyId, chatId]);
 
   const lastByUser = useMemo(() => {
     const map: Record<number, number> = {};


### PR DESCRIPTION
## Summary
- open user profiles from chat headers for managers and labourers
- allow profile screen to handle chat context and roles

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68ae5a01dea48320862e59ba5ddfe6da