### PR TITLE
Fix profile back navigation from chat

### DIFF
--- a/mobile/app/(labourer)/chats/[id].tsx
+++ b/mobile/app/(labourer)/chats/[id].tsx
@@ -191,15 +191,17 @@ export default function LabourerChatDetail() {
     }, [])
   );
 
-  // ----- Slide-to-go-back -----
+  // ----- Slide transitions -----
   const screenW = Dimensions.get("window").width;
-  const translateX = useRef(new Animated.Value(0)).current;
+  const translateX = useRef(new Animated.Value(screenW)).current;
 
-  useFocusEffect(
-    useCallback(() => {
-      translateX.setValue(0);
-    }, [translateX])
-  );
+  useEffect(() => {
+    Animated.timing(translateX, {
+      toValue: 0,
+      duration: 160,
+      useNativeDriver: true,
+    }).start();
+  }, [screenW, translateX]);
 
   const panBackResponder = useMemo(
     () =>
@@ -410,7 +412,16 @@ export default function LabourerChatDetail() {
         >
           {/* Header */}
           <View style={[styles.header, { paddingTop: insets.top + 6 }]}>
-            <Pressable onPress={goToList} hitSlop={12}>
+            <Pressable
+              onPress={() => {
+                Animated.timing(translateX, {
+                  toValue: screenW,
+                  duration: 160,
+                  useNativeDriver: true,
+                }).start(goToList);
+              }}
+              hitSlop={12}
+            >
               <Text style={styles.headerBack}>‹</Text>
             </Pressable>
             {otherPartyId ? (

--- a/mobile/app/(labourer)/profileDetails.tsx
+++ b/mobile/app/(labourer)/profileDetails.tsx
@@ -41,9 +41,6 @@ export default function LabourerProfileDetails() {
   const backJobId = getLast(params.jobId);
   const from = getLast(params.from);
   const viewRole = (getLast(params.role) ?? "manager") as RoleKey;
-  const chatId = params.chatId
-    ? parseInt(getLast(params.chatId)!, 10)
-    : undefined;
   const isOwn = viewUserId === authUserId;
 
   const profiles = useProfile((s) => s.profiles);
@@ -193,7 +190,7 @@ export default function LabourerProfileDetails() {
           <View style={[styles.topBar, { paddingTop: insets.top + 6 }]}>
             <Pressable
               onPress={() => {
-                if (from === "chat" && chatId != null) {
+                if (from === "chat") {
                   router.back();
                 } else if (backJobId) {
                   const dest = from === "jobs" ? "/(labourer)/jobs" : "/(labourer)/map";

--- a/mobile/app/(labourer)/profileDetails.tsx
+++ b/mobile/app/(labourer)/profileDetails.tsx
@@ -31,32 +31,19 @@ export default function LabourerProfileDetails() {
     from?: string;
     role?: string;
     chatId?: string;
-    viewer?: string;
   }>();
+  const getLast = <T,>(value: T | T[] | undefined): T | undefined =>
+    Array.isArray(value) ? value[value.length - 1] : value;
+
   const viewUserId = params.userId
-    ? parseInt(Array.isArray(params.userId) ? params.userId[0] : params.userId, 10)
+    ? parseInt(getLast(params.userId)!, 10)
     : authUserId;
-  const backJobId = params.jobId
-    ? Array.isArray(params.jobId) ? params.jobId[0] : params.jobId
-    : undefined;
-  const from = params.from
-    ? Array.isArray(params.from)
-      ? params.from[0]
-      : params.from
-    : undefined;
-  const viewRole = (params.role
-    ? Array.isArray(params.role)
-      ? params.role[0]
-      : params.role
-    : "manager") as RoleKey;
+  const backJobId = getLast(params.jobId);
+  const from = getLast(params.from);
+  const viewRole = (getLast(params.role) ?? "manager") as RoleKey;
   const chatId = params.chatId
-    ? parseInt(Array.isArray(params.chatId) ? params.chatId[0] : params.chatId, 10)
+    ? parseInt(getLast(params.chatId)!, 10)
     : undefined;
-  const viewer = (params.viewer
-    ? Array.isArray(params.viewer)
-      ? params.viewer[0]
-      : params.viewer
-    : undefined) as RoleKey | undefined;
   const isOwn = viewUserId === authUserId;
 
   const profiles = useProfile((s) => s.profiles);
@@ -206,15 +193,11 @@ export default function LabourerProfileDetails() {
           <View style={[styles.topBar, { paddingTop: insets.top + 6 }]}>
             <Pressable
               onPress={() => {
-                if (backJobId) {
+                if (from === "chat" && chatId != null) {
+                  router.back();
+                } else if (backJobId) {
                   const dest = from === "jobs" ? "/(labourer)/jobs" : "/(labourer)/map";
                   router.replace({ pathname: dest, params: { jobId: String(backJobId) } });
-                } else if (from === "chat" && chatId != null) {
-                  const dest =
-                    viewer === "manager"
-                      ? "/(manager)/chats/[id]"
-                      : "/(labourer)/chats/[id]";
-                  router.replace({ pathname: dest, params: { id: String(chatId) } });
                 } else {
                   router.replace(BACK_TO);
                 }


### PR DESCRIPTION
## Summary
- prioritize chat when handling profile back navigation to avoid landing on Jobs
- read the latest route params to discard stale job info

## Testing
- `npm test` *(fails: Missing script "test")*
- `cd mobile && npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68ae612221d883208644eec74a62189c