### PR TITLE
feat: add team invite flow

### DIFF
--- a/mobile/app/(auth)/login.tsx
+++ b/mobile/app/(auth)/login.tsx
@@ -4,9 +4,13 @@ import { router } from "expo-router";
 import { Colors } from "@src/theme/tokens";
 import { useAuth } from "@src/store/useAuth";
 import { Ionicons } from "@expo/vector-icons";
+import { acceptTeamInvite } from "@src/lib/api";
+import { useInviteToken } from "@src/store/useInviteToken";
 
 export default function Login() {
   const { signIn, lastRegisteredEmail } = useAuth();
+  const inviteToken = useInviteToken((s) => s.token);
+  const clearInviteToken = useInviteToken((s) => s.clear);
   const [email, setEmail] = useState("");
   const [password, setPassword] = useState("");
   const [err, setErr] = useState<string | null>(null);
@@ -20,6 +24,10 @@ export default function Login() {
     try {
       setErr(null);
       const role = await signIn(email.trim(), password);
+      if (inviteToken) {
+        try { await acceptTeamInvite(inviteToken); } catch {}
+        clearInviteToken();
+      }
       // Redirect to a *real* screen (not the group root)
       if (role === "labourer") router.replace("/(labourer)/jobs");
       else if (role === "manager") router.replace("/(manager)/projects");

--- a/mobile/app/(labourer)/chats/[id].tsx
+++ b/mobile/app/(labourer)/chats/[id].tsx
@@ -268,9 +268,11 @@ export default function LabourerChatDetail() {
         userId: String(otherPartyId),
         from: "chat",
         role: "manager",
+        chatId: String(chatId),
+        viewer: "labourer",
       },
     });
-  }, [otherPartyId]);
+  }, [otherPartyId, chatId]);
 
   const lastByUser = useMemo(() => {
     const map: Record<number, number> = {};

--- a/mobile/app/(labourer)/profileDetails.tsx
+++ b/mobile/app/(labourer)/profileDetails.tsx
@@ -30,6 +30,8 @@ export default function LabourerProfileDetails() {
     jobId?: string;
     from?: string;
     role?: string;
+    chatId?: string;
+    viewer?: string;
   }>();
   const viewUserId = params.userId
     ? parseInt(Array.isArray(params.userId) ? params.userId[0] : params.userId, 10)
@@ -47,6 +49,14 @@ export default function LabourerProfileDetails() {
       ? params.role[0]
       : params.role
     : "manager") as RoleKey;
+  const chatId = params.chatId
+    ? parseInt(Array.isArray(params.chatId) ? params.chatId[0] : params.chatId, 10)
+    : undefined;
+  const viewer = (params.viewer
+    ? Array.isArray(params.viewer)
+      ? params.viewer[0]
+      : params.viewer
+    : undefined) as RoleKey | undefined;
   const isOwn = viewUserId === authUserId;
 
   const profiles = useProfile((s) => s.profiles);
@@ -199,8 +209,12 @@ export default function LabourerProfileDetails() {
                 if (backJobId) {
                   const dest = from === "jobs" ? "/(labourer)/jobs" : "/(labourer)/map";
                   router.replace({ pathname: dest, params: { jobId: String(backJobId) } });
-                } else if (from === "chat") {
-                  router.back();
+                } else if (from === "chat" && chatId != null) {
+                  const dest =
+                    viewer === "manager"
+                      ? "/(manager)/chats/[id]"
+                      : "/(labourer)/chats/[id]";
+                  router.replace({ pathname: dest, params: { id: String(chatId) } });
                 } else {
                   router.replace(BACK_TO);
                 }

--- a/mobile/app/(manager)/chats/[id].tsx
+++ b/mobile/app/(manager)/chats/[id].tsx
@@ -287,9 +287,11 @@ export default function ManagerChatDetail() {
         userId: String(otherPartyId),
         from: "chat",
         role: "labourer",
+        chatId: String(chatId),
+        viewer: "manager",
       },
     });
-  }, [otherPartyId]);
+  }, [otherPartyId, chatId]);
 
   const lastByUser = useMemo(() => {
     const map: Record<number, number> = {};

--- a/mobile/app/(manager)/team.tsx
+++ b/mobile/app/(manager)/team.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from "react";
-import { View, FlatList, Text, StyleSheet, Pressable, Modal, ScrollView } from "react-native";
-import { listTeam } from "@src/lib/api";
+import { View, FlatList, Text, StyleSheet, Pressable, Modal, ScrollView, Share } from "react-native";
+import { listTeam, createTeamInvite } from "@src/lib/api";
 import TopBar from "@src/components/TopBar";
 import { Ionicons } from "@expo/vector-icons";
 import { Colors } from "@src/theme/tokens";
@@ -11,15 +11,28 @@ export default function ManagerTeam() {
   const [taskOpen, setTaskOpen] = useState(false);
   useEffect(() => { listTeam().then(setPeople); }, []);
 
+  const invite = async () => {
+    try {
+      const { link } = await createTeamInvite();
+      await Share.share({ message: link });
+    } catch {}
+  };
+
   return (
     <View style={styles.container}>
       <TopBar />
       <View style={styles.headerRow}>
         <Text style={styles.headerTitle}>My Team</Text>
-        <Pressable style={styles.createBtn} onPress={() => setTaskOpen(true)}>
-          <Ionicons name="add" size={18} />
-          <Text style={styles.createText}>Create task</Text>
-        </Pressable>
+        <View style={{ flexDirection: "row", gap: 8 }}>
+          <Pressable style={styles.createBtn} onPress={invite}>
+            <Ionicons name="person-add" size={18} />
+            <Text style={styles.createText}>Invite teammate</Text>
+          </Pressable>
+          <Pressable style={styles.createBtn} onPress={() => setTaskOpen(true)}>
+            <Ionicons name="add" size={18} />
+            <Text style={styles.createText}>Create task</Text>
+          </Pressable>
+        </View>
       </View>
       <FlatList
         contentContainerStyle={{ padding:12 }}

--- a/mobile/app/index.tsx
+++ b/mobile/app/index.tsx
@@ -2,6 +2,9 @@ import { Redirect } from "expo-router";
 import { useAuth } from "@src/store/useAuth";
 import { useEffect, useState } from "react";
 import { View } from "react-native";
+import * as Linking from "expo-linking";
+import { useInviteToken } from "@src/store/useInviteToken";
+import { acceptTeamInvite } from "@src/lib/api";
 
 export default function Index() {
   // Wait for persisted state to hydrate
@@ -15,7 +18,24 @@ export default function Index() {
     return () => unsub?.();
   }, []);
 
+  useEffect(() => {
+    const handle = (url: string) => {
+      const match = /invite\/([^/?]+)/.exec(url);
+      if (match) useInviteToken.getState().setToken(match[1]);
+    };
+    Linking.getInitialURL().then((url) => url && handle(url));
+    const sub = Linking.addEventListener("url", (e) => handle(e.url));
+    return () => sub.remove();
+  }, []);
   const { signedIn, role } = useAuth();
+  const token = useInviteToken((s) => s.token);
+  const clear = useInviteToken((s) => s.clear);
+
+  useEffect(() => {
+    if (signedIn && token) {
+      acceptTeamInvite(token).finally(() => clear());
+    }
+  }, [signedIn, token]);
 
   if (!ready) return <View />;
 
@@ -23,6 +43,6 @@ export default function Index() {
 
   // Go to concrete screens that actually exist
   if (role === "labourer") return <Redirect href="/(labourer)/jobs" />;
-  if (role === "manager")  return <Redirect href="/(manager)/projects" />;
+  if (role === "manager") return <Redirect href="/(manager)/projects" />;
   return <Redirect href="/(client)/projects/index" />;
 }

--- a/mobile/src/lib/api.ts
+++ b/mobile/src/lib/api.ts
@@ -675,4 +675,35 @@ export async function createProject(p: { title: string; site: string; when: stri
   _projects.push(proj);
   return Promise.resolve(proj);
 }
-export async function listTeam() { return Promise.resolve([{ id: 1, name: "Sam Carter", role: "Site Supervisor", status: "online" }]); }
+export async function listTeam() {
+  if (API_BASE) {
+    const token = useAuth.getState().token;
+    const r = await fetch(`${API_BASE}/team`, {
+      headers: headers(token ?? undefined),
+    });
+    if (!r.ok) throw new Error("Failed to fetch team");
+    return r.json();
+  }
+  return Promise.resolve([]);
+}
+
+export async function createTeamInvite(email?: string) {
+  if (!API_BASE) throw new Error("No API configured");
+  const token = useAuth.getState().token;
+  const r = await fetch(`${API_BASE}/team/invites`, {
+    method: "POST",
+    headers: headers(token ?? undefined),
+    body: JSON.stringify(email ? { email } : {}),
+  });
+  if (!r.ok) throw new Error("Failed to create invite");
+  return r.json();
+}
+
+export async function acceptTeamInvite(token: string) {
+  if (!API_BASE) return;
+  const auth = useAuth.getState().token;
+  await fetch(`${API_BASE}/team/invites/${token}/accept`, {
+    method: "POST",
+    headers: headers(auth ?? undefined),
+  });
+}

--- a/mobile/src/store/useInviteToken.ts
+++ b/mobile/src/store/useInviteToken.ts
@@ -1,0 +1,24 @@
+import { create } from "zustand";
+import { persist, createJSONStorage } from "zustand/middleware";
+import AsyncStorage from "@react-native-async-storage/async-storage";
+
+type State = {
+  token: string | null;
+  setToken: (t: string | null) => void;
+  clear: () => void;
+};
+
+export const useInviteToken = create<State>()(
+  persist(
+    (set) => ({
+      token: null,
+      setToken: (t) => set({ token: t }),
+      clear: () => set({ token: null }),
+    }),
+    {
+      name: "invite-token",
+      storage: createJSONStorage(() => AsyncStorage),
+    }
+  )
+);
+


### PR DESCRIPTION
## Summary
- add team membership and invite tables
- implement invite creation, acceptance and team listing routes
- support invite deep links in mobile app

## Testing
- `npm test` (fails: Missing script "test")
- `npm --prefix server test` (fails: Missing script "test")
- `npm --prefix mobile test` (fails: Missing script "test")

------
https://chatgpt.com/codex/tasks/task_e_68b1e07851108320a4f904b7dfe50e68