### PR TITLE
Show current jobs in manager team view

### DIFF
--- a/mobile/app/(manager)/projects.tsx
+++ b/mobile/app/(manager)/projects.tsx
@@ -21,6 +21,7 @@ import DateRangeSheet from "@src/components/DateRangeSheet";
 import { Colors } from "@src/theme/tokens";
 import { Ionicons } from "@expo/vector-icons";
 import * as ImagePicker from "expo-image-picker";
+import { parseWhenToDates } from "@src/lib/date";
 
 /* Map + geocoding */
 import MapView, { Region } from "react-native-maps";
@@ -34,22 +35,6 @@ function formatPay(pay?: string) {
   return t;
 }
 
-function parseWhenToDates(when?: string): { start: string; end: string } {
-  if (!when) return { start: "", end: "" };
-  const months: Record<string, number> = { jan:0,feb:1,mar:2,apr:3,may:4,jun:5,jul:6,aug:7,sep:8,oct:9,nov:10,dec:11 };
-  const [a,b] = when.split(" - ").map(s => s.trim());
-  const parse = (part?: string) => {
-    if (!part) return "";
-    const m = part.match(/^(\d{1,2})(?:st|nd|rd|th)?\s+([A-Za-z]+)/);
-    if (!m) return "";
-    const d = parseInt(m[1], 10);
-    const mon = months[m[2].slice(0,3).toLowerCase()];
-    if (isNaN(d) || mon == null) return "";
-    const dt = new Date(Date.UTC(2025, mon, d));
-    return dt.toISOString().slice(0,10);
-  };
-  return { start: parse(a), end: parse(b) };
-}
 
 const DEFAULT_REGION: Region = {
   latitude: 51.5074,

--- a/mobile/src/lib/date.ts
+++ b/mobile/src/lib/date.ts
@@ -2,3 +2,33 @@ export function parseDate(value: string): Date {
   if (!value) return new Date(NaN);
   return new Date(value.includes('T') ? value : value.replace(' ', 'T') + 'Z');
 }
+
+export function parseWhenToDates(when?: string): { start: string; end: string } {
+  if (!when) return { start: "", end: "" };
+  const months: Record<string, number> = {
+    jan: 0,
+    feb: 1,
+    mar: 2,
+    apr: 3,
+    may: 4,
+    jun: 5,
+    jul: 6,
+    aug: 7,
+    sep: 8,
+    oct: 9,
+    nov: 10,
+    dec: 11,
+  };
+  const [a, b] = when.split(" - ").map((s) => s.trim());
+  const parse = (part?: string) => {
+    if (!part) return "";
+    const m = part.match(/^(\d{1,2})(?:st|nd|rd|th)?\s+([A-Za-z]+)/);
+    if (!m) return "";
+    const d = parseInt(m[1], 10);
+    const mon = months[m[2].slice(0, 3).toLowerCase()];
+    if (isNaN(d) || mon == null) return "";
+    const dt = new Date(Date.UTC(2025, mon, d));
+    return dt.toISOString().slice(0, 10);
+  };
+  return { start: parse(a), end: parse(b) };
+}


### PR DESCRIPTION
## Summary
- Display manager's current jobs in team screen by fetching jobs and filtering date ranges
- Extract `parseWhenToDates` helper to shared date utility and reuse in projects and team views
- Render job tiles with image and live icon; update header and empty state

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b42f2a8c748327bb5ea18765f13b62