### PR TITLE
feat: add PayPal subscription flow

### DIFF
--- a/mobile/app/(manager)/subscriptions.tsx
+++ b/mobile/app/(manager)/subscriptions.tsx
@@ -1,28 +1,64 @@
-import React, { useState } from "react";
-import { View, Text, StyleSheet, ScrollView, Pressable, Alert, Switch } from "react-native";
+import React, { useState, useEffect } from "react";
+import {
+  View,
+  Text,
+  StyleSheet,
+  ScrollView,
+  Pressable,
+  Alert,
+  Switch,
+  Linking,
+} from "react-native";
 import { Colors } from "@src/theme/tokens";
 import { Stack, router } from "expo-router";
 import { Ionicons } from "@expo/vector-icons";
+import { useAuth } from "@src/store/useAuth";
 
 const PROFILE_DETAILS = "/(manager)/profile" as const;
 type Plan = "Free" | "Pro";
 
 export default function Subscriptions() {
+  const { user, token } = useAuth();
   const [plan, setPlan] = useState<Plan>("Free");
   const [autoRenew, setAutoRenew] = useState(true);
   const [emailInvoices, setEmailInvoices] = useState(true);
 
-  const save = () => {
-    // TODO: wire to billing backend
-    Alert.alert(
-      "Saved",
-      `Plan: ${plan}\nAuto-renew: ${autoRenew ? "On" : "Off"}\nEmail invoices: ${emailInvoices ? "On" : "Off"}`
-    );
+  const API_BASE = process.env.EXPO_PUBLIC_API_BASE_URL;
+
+  useEffect(() => {
+    if (user?.subscription_plan === "pro") setPlan("Pro");
+  }, [user]);
+
+  const save = async () => {
+    if (!API_BASE) return Alert.alert("Error", "API not configured");
+    try {
+      if (plan === "Pro" && user?.subscription_plan !== "pro") {
+        const r = await fetch(`${API_BASE}/billing/checkout`, {
+          method: "POST",
+          headers: { Authorization: `Bearer ${token}` },
+        });
+        const data = await r.json();
+        if (data.url) Linking.openURL(data.url);
+      } else {
+        const r = await fetch(`${API_BASE}/billing/portal`, {
+          headers: { Authorization: `Bearer ${token}` },
+        });
+        const data = await r.json();
+        if (data.url) Linking.openURL(data.url);
+      }
+      const r2 = await fetch(`${API_BASE}/me`, {
+        headers: { Authorization: `Bearer ${token}` },
+      });
+      if (r2.ok) {
+        const d2 = await r2.json();
+        useAuth.setState({ user: d2.user });
+      }
+    } catch (e) {
+      Alert.alert("Error", "Failed to update subscription");
+    }
   };
 
-  const managePlan = () => {
-    Alert.alert("Manage plan", "This would open your billing portal.");
-  };
+  const managePlan = save;
 
   return (
     <>

--- a/mobile/src/store/useAuth.ts
+++ b/mobile/src/store/useAuth.ts
@@ -4,7 +4,15 @@ import AsyncStorage from "@react-native-async-storage/async-storage";
 
 type Role = "client" | "manager" | "labourer";
 type PendingReg = { username: string; email: string; password: string } | null;
-type User = { id: number; email: string; username: string; role: Role };
+type User = {
+  id: number;
+  email: string;
+  username: string;
+  role: Role;
+  subscription_plan: "free" | "pro";
+  subscription_status: "active" | "inactive" | "past_due";
+  paypal_subscription_id?: string | null;
+};
 
 type State = {
   role: Role | null;
@@ -63,7 +71,10 @@ export const useAuth = create<State>()(
             id: 0,
             email,
             username: email.split("@")[0] || "Demo User",
-            role: resolvedRole
+            role: resolvedRole,
+            subscription_plan: "free",
+            subscription_status: "inactive",
+            paypal_subscription_id: null,
           };
           set({ signedIn: true, token: "demo", role: resolvedRole, user: demoUser });
         }
@@ -76,7 +87,10 @@ export const useAuth = create<State>()(
           id: 0,
           email: `${role}@guest.local`,
           username: `Guest ${role.charAt(0).toUpperCase()}${role.slice(1)}`,
-          role
+          role,
+          subscription_plan: "free",
+          subscription_status: "inactive",
+          paypal_subscription_id: null,
         };
         set({ role, signedIn: true, token: "guest", user: demoUser });
         return role;
@@ -127,3 +141,6 @@ export const useAuth = create<State>()(
     }
   )
 );
+
+export const useIsPro = () =>
+  useAuth((s) => s.user?.subscription_plan === "pro");


### PR DESCRIPTION
## Summary
- add PayPal client utilities and subscription fields to users table
- expose subscription plan and status through auth responses
- wire mobile auth store and subscription screens to PayPal checkout/portal

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm --prefix server test` *(fails: Missing script: "test")*
- `npm --prefix mobile test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68b3747300ec8320b5c3de4927c993f5