### PR TITLE
Enable profile management and AI chat for clients

### DIFF
--- a/mobile/app/(client)/_layout.tsx
+++ b/mobile/app/(client)/_layout.tsx
@@ -2,9 +2,11 @@ import { Tabs, Redirect } from "expo-router";
 import { useAuth } from "@src/store/useAuth";
 import { Ionicons } from "@expo/vector-icons";
 import { Colors } from "@src/theme/tokens";
+import { useNotifications } from "@src/store/useNotifications";
 
 export default function ClientTabs() {
   const { signedIn } = useAuth();
+  const unread = useNotifications((s) => s.unread.client);
   if (!signedIn) return <Redirect href="/(auth)/welcome" />;
 
   return (
@@ -17,14 +19,18 @@ export default function ClientTabs() {
         tabBarIcon: ({ focused, size, color }) => {
           const name = (() => {
             switch (route.name) {
-              case "chats": return focused ? "chatbubbles" : "chatbubbles-outline";
-              case "projects/index": return focused ? "briefcase" : "briefcase-outline";
-              case "map": return focused ? "map" : "map-outline";
-              default: return "ellipse-outline";
+              case "chats":
+                return focused ? "chatbubbles" : "chatbubbles-outline";
+              case "projects/index":
+                return focused ? "briefcase" : "briefcase-outline";
+              case "map":
+                return focused ? "map" : "map-outline";
+              default:
+                return "ellipse-outline";
             }
           })();
           return <Ionicons name={name as any} size={size} color={color} />;
-        }
+        },
       })}
     >
       {/* hidden routes */}
@@ -32,9 +38,13 @@ export default function ClientTabs() {
       <Tabs.Screen name="projects/[id]" options={{ href: null }} />
       <Tabs.Screen name="chats/[id]" options={{ href: null }} />
       <Tabs.Screen name="profile" options={{ href: null }} />
+      <Tabs.Screen name="profileDetails" options={{ href: null }} />
 
       {/* visible tabs */}
-      <Tabs.Screen name="chats" options={{ title: "Chats" }} />
+      <Tabs.Screen
+        name="chats"
+        options={{ title: "Chats", tabBarBadge: unread > 0 ? unread : undefined }}
+      />
       <Tabs.Screen name="projects/index" options={{ title: "Projects" }} />
       <Tabs.Screen name="map" options={{ title: "Map" }} />
     </Tabs>

--- a/mobile/app/(client)/chats.tsx
+++ b/mobile/app/(client)/chats.tsx
@@ -1,58 +1,184 @@
-import { useEffect, useState } from "react";
-import { View, FlatList, Text, TextInput, Pressable, StyleSheet } from "react-native";
-import { listChats } from "@src/lib/api";
-import { router } from "expo-router";
+import { useEffect, useState, useCallback } from "react";
+import { View, FlatList, Text, Pressable, StyleSheet, Image, Alert } from "react-native";
 import TopBar from "@src/components/TopBar";
+import { listChats, type Chat, deleteChat } from "@src/lib/api";
+import { parseDate } from "@src/lib/date";
+import { useAuth } from "@src/store/useAuth";
+import { useFocusEffect, router } from "expo-router";
+import { useNotifications } from "@src/store/useNotifications";
+import { Ionicons } from "@expo/vector-icons";
+import { useProfile } from "@src/store/useProfile";
+import { useChatBadge } from "@src/store/useChatBadge";
+import { Swipeable } from "react-native-gesture-handler";
 
-export default function ClientChats() {
-  const [q, setQ] = useState("");
-  const [items, setItems] = useState<any[]>([]);
-  useEffect(() => { listChats().then(setItems); }, []);
-  const filtered = items.filter((t:any) =>
-    ((t.title ?? "") + " " + (t.lastMessage ?? "")).toLowerCase().includes(q.toLowerCase())
+export default function Chats() {
+  const { user } = useAuth();
+  const userId = user?.id ?? 0;
+  const [items, setItems] = useState<Chat[]>([]);
+  const { clear } = useNotifications();
+  const profiles = useProfile((s) => s.profiles);
+  const lastSeen = useChatBadge((s) => s.lastSeenByChat);
+
+  const load = useCallback(async () => {
+    const data = await listChats(user?.id);
+    setItems(Array.isArray(data) ? data : []);
+  }, [user?.id]);
+
+  const handleDelete = (id: number) => {
+    Alert.alert("Delete chat?", "Are you sure you want to delete chat?", [
+      { text: "Cancel", style: "cancel" },
+      {
+        text: "Delete",
+        style: "destructive",
+        onPress: async () => {
+          if (id === 0) {
+            await deleteChat(0);
+            load();
+          } else {
+            setItems((prev) => prev.filter((c) => c.id !== id));
+            await deleteChat(id);
+          }
+        },
+      },
+    ]);
+  };
+
+  useFocusEffect(
+    useCallback(() => {
+      clear("client");
+      load();
+    }, [clear, load])
   );
 
+  useEffect(() => {
+    const t = setInterval(load, 5000);
+    return () => clearInterval(t);
+  }, [load]);
+
+  const renderRow = ({ item }: { item: Chat }) => {
+    const otherId =
+      item.memberIds?.find((id) => id !== userId) ??
+      (item.workerId === userId ? item.managerId : item.workerId);
+    const avatarUri = otherId ? profiles[otherId]?.avatarUri : undefined;
+    const seen = lastSeen[item.id];
+    const isUnread = item.lastTime
+      ? !seen || parseDate(seen) < parseDate(item.lastTime)
+      : false;
+
+    return (
+      <Swipeable
+        renderRightActions={() => (
+          <Pressable style={styles.delete} onPress={() => handleDelete(item.id)}>
+            <Ionicons name="trash" size={20} color="#fff" />
+            <Text style={styles.deleteText}>Delete</Text>
+          </Pressable>
+        )}
+      >
+        <Pressable
+          onPress={() => router.push(`/(client)/chats/${item.id}`)}
+          style={styles.row}
+        >
+          {item.id === 0 ? (
+            <Image
+              source={require("../../assets/images/ConstructionAI.png")}
+              style={styles.avatar}
+            />
+          ) : avatarUri ? (
+            <Image source={{ uri: avatarUri }} style={styles.avatar} />
+          ) : (
+            <View style={[styles.avatar, styles.silhouette]}>
+              <Ionicons name="person" size={18} color="#9CA3AF" />
+            </View>
+          )}
+
+          <View style={{ flex: 1 }}>
+            <Text style={styles.title} numberOfLines={1}>
+              {item.title || "Chat"}
+            </Text>
+            {!!item.lastMessage && (
+              <Text style={styles.sub} numberOfLines={1}>
+                {item.lastMessage}
+              </Text>
+            )}
+          </View>
+
+          <View style={styles.right}>
+            {isUnread && <View style={styles.unread} />}
+            <Ionicons name="chevron-forward" size={18} color="#9CA3AF" />
+          </View>
+        </Pressable>
+      </Swipeable>
+    );
+  };
+
   return (
-    <View style={styles.container}>
+    <View style={{ flex: 1, backgroundColor: "#fff" }}>
       <TopBar />
-      <View style={{ padding:12 }}>
-        <TextInput placeholder="Search chats" value={q} onChangeText={setQ} style={styles.search} />
-        <FlatList
-          data={filtered}
-          keyExtractor={(i) => String(i.id)}
-          renderItem={({ item }) => {
-            const title: string = item.title ?? "Chat";
-            const initial = title.slice(0, 1).toUpperCase();
-            return (
-              <Pressable
-                style={styles.row}
-                onPress={() => router.push({ pathname: "/(client)/chats/[id]", params: { id: String(item.id) } })}
-              >
-                <View style={styles.avatar}><Text style={styles.avatarText}>{initial}</Text></View>
-                <View style={{ flex: 1 }}>
-                  <Text style={styles.name}>{title}</Text>
-                  <Text numberOfLines={1} style={styles.preview}>{item.lastMessage ?? ""}</Text>
-                </View>
-                <Text style={styles.time}>{item.lastTime ?? ""}</Text>
-              </Pressable>
-            );
-          }}
-          ItemSeparatorComponent={() => <View style={styles.sep} />}
-        />
-      </View>
+      <FlatList
+        data={items}
+        keyExtractor={(c) => String(c.id)}
+        renderItem={renderRow}
+        ItemSeparatorComponent={() => <View style={{ height: 8 }} />}
+        contentContainerStyle={{ padding: 12, flexGrow: 1 }}
+        ListEmptyComponent={
+          <View style={styles.emptyWrap}>
+            <View style={styles.emptyBadge}>
+              <Ionicons name="chatbubbles-outline" size={22} color="#6B7280" />
+            </View>
+            <Text style={styles.emptyTitle}>No chats yet</Text>
+            <Text style={styles.emptyText}>
+              Start a project or message a manager to start a conversation.
+            </Text>
+          </View>
+        }
+      />
     </View>
   );
 }
 
 const styles = StyleSheet.create({
-  container:{ flex:1, backgroundColor:"#fff" },
-  search:{ borderWidth:1, borderColor:"#e5e5e5", borderRadius:12, padding:10, marginBottom:8 },
-  row:{ flexDirection:"row", alignItems:"center", paddingVertical:10 },
-  avatar:{ width:40, height:40, borderRadius:20, alignItems:"center", justifyContent:"center",
-           borderWidth:1, borderColor:"#eee", marginRight:12, backgroundColor:"#f6f8fa" },
-  avatarText:{ fontWeight:"700" },
-  name:{ fontWeight:"600" },
-  preview:{ color:"#666", marginTop:2 },
-  time:{ color:"#999", marginLeft:8 },
-  sep:{ height:1, backgroundColor:"#f0f0f0" }
+  row: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: 10,
+    padding: 12,
+    borderWidth: 1,
+    borderColor: "#eee",
+    borderRadius: 12,
+    backgroundColor: "#fff",
+  },
+  delete: {
+    backgroundColor: "#EF4444",
+    justifyContent: "center",
+    alignItems: "center",
+    width: 72,
+    borderRadius: 12,
+    marginLeft: 8,
+  },
+  deleteText: { color: "#fff", fontWeight: "600", marginTop: 4 },
+  avatar: { width: 44, height: 44, borderRadius: 22, backgroundColor: "#E5E7EB" },
+  silhouette: { alignItems: "center", justifyContent: "center" },
+  title: { fontWeight: "700", color: "#1F2937" },
+  sub: { color: "#6B7280", marginTop: 2 },
+
+  right: { flexDirection: "row", alignItems: "center", gap: 6 },
+  unread: { width: 10, height: 10, borderRadius: 5, backgroundColor: "#16A34A" },
+
+  emptyWrap: {
+    flex: 1,
+    alignItems: "center",
+    justifyContent: "center",
+    paddingHorizontal: 24,
+  },
+  emptyBadge: {
+    width: 52,
+    height: 52,
+    borderRadius: 26,
+    backgroundColor: "#F3F4F6",
+    alignItems: "center",
+    justifyContent: "center",
+    marginBottom: 10,
+  },
+  emptyTitle: { fontSize: 16, fontWeight: "800", color: "#111827" },
+  emptyText: { marginTop: 6, color: "#6B7280", textAlign: "center" },
 });

--- a/mobile/app/(client)/chats/[id].tsx
+++ b/mobile/app/(client)/chats/[id].tsx
@@ -1,49 +1,102 @@
-import React, { useEffect, useRef, useState, useCallback, useMemo } from "react";
+import React, { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import {
   View,
   Text,
   FlatList,
   TextInput,
   Pressable,
-  StyleSheet,
   KeyboardAvoidingView,
   Platform,
-  Image,
-  Animated,
   Keyboard,
   LayoutAnimation,
   UIManager,
+  StyleSheet,
+  PanResponder,
+  LayoutChangeEvent,
+  Animated,
+  Dimensions,
+  BackHandler,
+  Image,
 } from "react-native";
-import { useLocalSearchParams } from "expo-router";
-import { listMessages, sendMessage, getSocket, type Message } from "@src/lib/api";
-import { parseDate } from "@src/lib/date";
+import { Stack, router, useLocalSearchParams } from "expo-router";
+import { useFocusEffect } from "@react-navigation/native";
+import { useSafeAreaInsets } from "react-native-safe-area-context";
+import { Colors } from "@src/theme/tokens";
+import {
+  listMessages,
+  sendMessage,
+  getChat,
+  getApplicationForChat,
+  type Message,
+  type Chat,
+  getSocket,
+  fetchProfile,
+} from "@src/lib/api";
 import { useAuth } from "@src/store/useAuth";
+import { useNotifications } from "@src/store/useNotifications";
+import { useChatBadge } from "@src/store/useChatBadge";
 import { useProfile } from "@src/store/useProfile";
 import { Ionicons } from "@expo/vector-icons";
 import MarkdownText from "@src/components/MarkdownText";
+import { parseDate } from "@src/lib/date";
+import ThinkingDots from "@src/components/ThinkingDots";
 
-export default function ClientChatThread() {
+const GO_BACK_TO = "/(client)/chats";
+
+export default function ClientChatDetail() {
   const { id } = useLocalSearchParams<{ id: string }>();
   const chatId = Number(id);
-  const { user } = useAuth();
+  const { user, token } = useAuth();
   const myId = user?.id ?? 0;
   const myName = user?.username ?? "You";
   const profiles = useProfile((s) => s.profiles);
-  const [items, setItems] = useState<Message[]>([]);
-  const [text, setText] = useState("");
+  const upsertProfile = useProfile((s) => s.upsertProfile);
+
+  const insets = useSafeAreaInsets();
+
+  const [messages, setMessages] = useState<Message[]>([]);
+  const [chat, setChat] = useState<Chat | undefined>(undefined);
+  const [appStatus, setAppStatus] = useState<"pending" | "accepted" | "declined" | null>(null);
+  const [input, setInput] = useState("");
+  const [composerHeight, setComposerHeight] = useState(54);
+  const [thinking, setThinking] = useState(false);
+
   const listRef = useRef<FlatList<Message>>(null);
 
+  const load = useCallback(async (id: number = chatId) => {
+    const [data, meta, app] = await Promise.all([
+      listMessages(id),
+      getChat(id),
+      id === 0 ? Promise.resolve(null) : getApplicationForChat(id),
+    ]);
+    if (id !== chatId) return;
+    setMessages(Array.isArray(data) ? data : []);
+    setChat(meta);
+    setAppStatus(app?.status ?? null);
+    if (data.length) {
+      const last = data[data.length - 1].created_at;
+      useChatBadge.getState().markChatSeen(id, last);
+    }
+  }, [chatId]);
+
+  useFocusEffect(
+    useCallback(() => {
+      load(chatId);
+    }, [chatId, load])
+  );
+
   useEffect(() => {
-    let mounted = true;
-    listMessages(chatId).then((m) => {
-      if (mounted) setItems(m);
-    });
+    requestAnimationFrame(() => listRef.current?.scrollToEnd({ animated: true }));
+  }, [messages.length]);
+
+  useEffect(() => {
+    if (chatId === 0) return;
     const s = getSocket();
     if (s) {
       s.emit("join", { chatId });
       const handler = (msg: Message) => {
         if (msg.chat_id === chatId) {
-          setItems((prev) => {
+          setMessages((prev) => {
             const idx = prev.findIndex(
               (m) => m.id < 0 && m.body === msg.body && m.user_id === msg.user_id
             );
@@ -55,40 +108,15 @@ export default function ClientChatThread() {
             return [...prev, msg];
           });
           listRef.current?.scrollToEnd({ animated: true });
+          useChatBadge.getState().markChatSeen(chatId, msg.created_at);
         }
       };
       s.on("message:new", handler);
       return () => {
-        mounted = false;
         s.off("message:new", handler);
       };
     }
-    return () => {
-      mounted = false;
-    };
   }, [chatId]);
-
-  const onSend = useCallback(async () => {
-    const body = text.trim();
-    if (!body) return;
-    setText("");
-    const optimistic: Message = {
-      id: -Date.now(),
-      chat_id: chatId,
-      user_id: myId,
-      username: myName,
-      body,
-      created_at: new Date().toISOString(),
-    };
-    setItems((prev) => [...prev, optimistic]);
-    requestAnimationFrame(() => listRef.current?.scrollToEnd({ animated: true }));
-    try {
-      await sendMessage(chatId, body);
-    } catch {
-      setItems((prev) => prev.filter((m) => m.id !== optimistic.id));
-      setText(body);
-    }
-  }, [chatId, text, myId, myName]);
 
   useEffect(() => {
     if (Platform.OS === "android" && UIManager.setLayoutAnimationEnabledExperimental) {
@@ -108,26 +136,195 @@ export default function ClientChatThread() {
     };
   }, []);
 
+  // Load the other party's profile so we can display their name
+  useEffect(() => {
+    if (!chat || !token || chatId === 0) return;
+    const otherId =
+      chat.memberIds?.find((id) => id !== myId) ??
+      (myId === chat.managerId ? chat.workerId : chat.managerId);
+    if (!otherId) return;
+    const existing = profiles[otherId];
+    if (existing && existing.name !== "Manager" && existing.name !== "Labourer") return;
+    (async () => {
+      const remote = await fetchProfile(otherId, token);
+      if (remote) upsertProfile(remote);
+    })();
+  }, [chat, chatId, myId, token, profiles, upsertProfile]);
+
+  const displayMessages = useMemo(() => {
+    if (thinking) {
+      return [
+        ...messages,
+        {
+          id: -1,
+          chat_id: chatId,
+          user_id: 0,
+          username: "Construction AI",
+          body: "",
+          created_at: new Date().toISOString(),
+        },
+      ];
+    }
+    return messages;
+  }, [thinking, messages, chatId]);
+
+  const onSend = useCallback(async () => {
+    const body = input.trim();
+    if (!body) return;
+    setInput("");
+
+    const optimistic: Message = {
+      id: -Date.now(),
+      chat_id: chatId,
+      user_id: myId,
+      username: myName,
+      body,
+      created_at: new Date().toISOString(),
+    };
+    setMessages((prev) => [...prev, optimistic]);
+    if (chatId === 0) setThinking(true);
+    try {
+      const reply = await sendMessage(chatId, body, myName);
+      if (chatId === 0 && reply) {
+        // Add the AI reply to the message list
+        setMessages((prev) => [...prev, reply]);
+        // Mark the AI chat as read using the reply’s timestamp
+        useChatBadge.getState().markChatSeen(0, reply.created_at);
+      } else {
+        // Notify other roles for a new human message
+        useNotifications.getState().bumpMany(["manager", "labourer"]);
+      }
+    } catch {
+      // Roll back the optimistic message for both AI and human chats
+      setMessages((prev) => prev.filter((m) => m.id !== optimistic.id));
+      setInput(body);
+    } finally {
+      if (chatId === 0) setThinking(false);
+    }
+  }, [chatId, input, myName, myId]);
+
+  // ----- Always go to the Chats list -----
+  const goToList = useCallback(() => {
+    router.replace(GO_BACK_TO);
+  }, []);
+
+  // Android hardware back -> Chats list
+  useFocusEffect(
+    useCallback(() => {
+      const onBackPress = () => {
+        router.replace(GO_BACK_TO);
+        return true;
+      };
+      const sub = BackHandler.addEventListener("hardwareBackPress", onBackPress);
+      return () => sub.remove();
+    }, [])
+  );
+
+  // ----- Slide-to-go-back -----
+  const screenW = Dimensions.get("window").width;
+  const translateX = useRef(new Animated.Value(0)).current;
+
+  useFocusEffect(
+    useCallback(() => {
+      translateX.setValue(0);
+    }, [translateX])
+  );
+
+  const panBackResponder = useMemo(
+    () =>
+      PanResponder.create({
+        onStartShouldSetPanResponder: () => false,
+        onMoveShouldSetPanResponder: (_, g) =>
+          Math.abs(g.dx) > 12 && Math.abs(g.dx) > Math.abs(g.dy) && g.dx > 0,
+        onPanResponderMove: (_, g) => {
+          if (g.dx > 0) translateX.setValue(g.dx);
+        },
+        onPanResponderRelease: (_, g) => {
+          if (g.dx > 80) {
+            Animated.timing(translateX, {
+              toValue: screenW,
+              duration: 160,
+              useNativeDriver: true,
+            }).start(goToList);
+          } else {
+            Animated.spring(translateX, { toValue: 0, useNativeDriver: true }).start();
+          }
+        },
+      }),
+    [goToList, screenW, translateX]
+  );
+
+  // Swipe down on composer to dismiss keyboard
+  const panKeyboardResponder = useMemo(
+    () =>
+      PanResponder.create({
+        onStartShouldSetPanResponder: () => false,
+        onMoveShouldSetPanResponder: (_, g) => Math.abs(g.dy) > 6,
+        onPanResponderMove: (_, g) => {
+          if (g.dy > 30) Keyboard.dismiss();
+        },
+      }),
+    []
+  );
+
+  const otherPartyId = useMemo(() => {
+    if (!chat) return undefined;
+    const fromMembers = chat.memberIds?.find((id) => id !== myId);
+    if (fromMembers) return fromMembers;
+    return myId === chat.managerId ? chat.workerId : chat.managerId;
+  }, [chat, myId]);
+
+  const otherProfile = otherPartyId ? profiles[otherPartyId] : undefined;
+
+  const otherPartyName = useMemo(() => {
+    if (chatId === 0) return "Construction AI";
+    const name = otherProfile?.name;
+    if (name && name !== "Manager" && name !== "Labourer") return name;
+    const msgName = messages.find(
+      (m) => m.user_id !== myId && m.username !== "system"
+    )?.username;
+    if (msgName && msgName !== "Manager" && msgName !== "Labourer") return msgName;
+    const title = chat?.title;
+    if (title && !title.startsWith("Job:")) return title;
+    return "Chat";
+  }, [chatId, otherProfile, messages, myId, chat]);
+
+  const goToProfile = useCallback(() => {
+    if (!otherPartyId) return;
+    const role = otherPartyId === chat?.managerId ? "manager" : "labourer";
+    router.push({
+      pathname: "/(client)/profileDetails",
+      params: {
+        userId: String(otherPartyId),
+        from: "chat",
+        role,
+        chatId: String(chatId),
+        viewer: "client",
+      },
+    });
+  }, [otherPartyId, chatId, chat]);
+
   const lastByUser = useMemo(() => {
     const map: Record<number, number> = {};
-    for (let i = items.length - 1; i >= 0; i--) {
-      const m = items[i];
-      if (m.user_id != null && map[m.user_id] == null) {
+    for (let i = messages.length - 1; i >= 0; i--) {
+      const m = messages[i];
+      if (m.user_id != null && m.username !== "system" && map[m.user_id] == null) {
         map[m.user_id] = m.id;
       }
     }
     return map;
-  }, [items]);
+  }, [messages]);
 
   const [lastAnimatedId, setLastAnimatedId] = useState<number | null>(null);
   useEffect(() => {
-    if (items.length) {
-      const id = items[items.length - 1].id;
+    if (messages.length) {
+      const id = messages[messages.length - 1].id;
       setLastAnimatedId(id);
       const t = setTimeout(() => setLastAnimatedId(null), 250);
       return () => clearTimeout(t);
     }
-  }, [items.length]);
+  }, [messages]);
+
   const AnimatedMessage = ({
     children,
     animate,
@@ -155,33 +352,63 @@ export default function ClientChatThread() {
     }, [animate, opacity, translateY]);
     return (
       <Animated.View
-        style={{ opacity, transform: [{ translateY }], maxWidth: "80%" }}
+        style={{ opacity, transform: [{ translateY }], maxWidth: "82%" }}
       >
         {children}
       </Animated.View>
     );
   };
-
-  const renderItem = ({ item, index }: { item: Message; index: number }) => {
-    const isMine = item.user_id === myId;
+  const renderItem = ({ item }: { item: Message; index: number }) => {
+    if (item.id === -1) {
+      return (
+        <View style={[styles.row, styles.rowTheirs]}>
+          <Image
+            source={require("../../../assets/images/ConstructionAI.png")}
+            style={styles.avatar}
+          />
+          <View style={[styles.bubble, styles.bubbleTheirs]}>
+            <ThinkingDots />
+          </View>
+        </View>
+      );
+    }
+    const isSystem = item.username === "system";
+    const isMine = !isSystem && item.user_id === myId;
     const avatarUri = profiles[item.user_id || 0]?.avatarUri;
-    const showAvatar = item.user_id != null && item.id === lastByUser[item.user_id];
+    const showAvatar = !isSystem && item.id === lastByUser[item.user_id || 0];
+
+    if (isSystem) {
+      return (
+        <View style={styles.systemWrap}>
+          <MarkdownText style={styles.systemText}>{item.body}</MarkdownText>
+        </View>
+      );
+    }
+
     const avatar = avatarUri ? (
       <Image source={{ uri: avatarUri }} style={styles.avatar} />
+        ) : item.user_id === 0 ? (
+      <Image
+        source={require("../../../assets/images/ConstructionAI.png")}
+        style={styles.avatar}
+      />
     ) : (
       <View style={[styles.avatar, styles.silhouette]}>
         <Ionicons name="person" size={18} color="#9CA3AF" />
       </View>
     );
+
     const animate = item.id === lastAnimatedId;
     return (
       <View style={[styles.row, isMine ? styles.rowMine : styles.rowTheirs]}>
         {!isMine && showAvatar && avatar}
         <AnimatedMessage animate={animate}>
           <View style={[styles.bubble, isMine ? styles.bubbleMine : styles.bubbleTheirs]}>
-            <MarkdownText style={styles.body}>{item.body}</MarkdownText>
+            <MarkdownText style={[styles.text, isMine ? styles.textMine : styles.textTheirs]}>
+              {item.body}
+            </MarkdownText>
             {item.created_at ? (
-              <Text style={[styles.meta, isMine ? styles.metaMine : styles.metaTheirs]}>
+              <Text style={[styles.time, isMine ? styles.timeMine : styles.timeTheirs]}>
                 {parseDate(item.created_at).toLocaleTimeString([], {
                   hour: "2-digit",
                   minute: "2-digit",
@@ -195,36 +422,158 @@ export default function ClientChatThread() {
     );
   };
 
+  const keyExtractor = (m: Message) => String(m.id);
+  const onComposerLayout = (e: LayoutChangeEvent) =>
+    setComposerHeight(Math.max(40, Math.round(e.nativeEvent.layout.height)));
+
   return (
-    <KeyboardAvoidingView
-      style={{ flex: 1 }}
-      behavior={Platform.OS === "ios" ? "padding" : undefined}
-      keyboardVerticalOffset={84}
-    >
-      <FlatList
-        ref={listRef}
-        data={items}
-        keyExtractor={(m) => String(m.id)}
-        renderItem={renderItem}
-        contentContainerStyle={{ padding: 12 }}
-        onContentSizeChange={() => listRef.current?.scrollToEnd({ animated: true })}
-      />
-      <View style={styles.inputRow}>
-        <TextInput
-          value={text}
-          onChangeText={setText}
-          placeholder="Type a message"
-          style={styles.input}
-        />
-        <Pressable onPress={onSend} style={styles.send}>
-          <Text style={{ color: "#fff", fontWeight: "700" }}>Send</Text>
-        </Pressable>
-      </View>
-    </KeyboardAvoidingView>
+    <>
+      <Stack.Screen options={{ headerShown: false }} />
+      <KeyboardAvoidingView
+        style={styles.flex}
+        behavior={Platform.OS === "ios" ? "padding" : "height"}
+        keyboardVerticalOffset={Platform.OS === "ios" ? 5 : 0}
+      >
+        <Animated.View
+          style={[styles.container, { transform: [{ translateX }] }]}
+          {...panBackResponder.panHandlers}
+        >
+          {/* Header */}
+          <View style={[styles.header, { paddingTop: insets.top + 6 }]}>
+            <Pressable onPress={goToList} hitSlop={12}>
+              <Text style={styles.headerBack}>‹</Text>
+            </Pressable>
+            {otherPartyId ? (
+              <Pressable onPress={goToProfile} hitSlop={12}>
+                {otherProfile?.avatarUri ? (
+                  <Image source={{ uri: otherProfile.avatarUri }} style={styles.avatar} />
+                ) : (
+                  <View style={[styles.avatar, styles.silhouette]}>
+                    <Ionicons name="person" size={18} color="#9CA3AF" />
+                  </View>
+                )}
+              </Pressable>
+            ) : (
+              <Image
+                source={require("../../../assets/images/ConstructionAI.png")}
+                style={styles.avatar}
+              />
+            )}
+            <Pressable
+              onPress={goToProfile}
+              disabled={!otherPartyId}
+              style={{ flex: 1 }}
+              hitSlop={12}
+            >
+              <Text style={styles.headerTitle} numberOfLines={1}>
+                {otherPartyName}
+              </Text>
+            </Pressable>
+            <View style={{ width: 18 }} />
+          </View>
+
+          {/* Status chip */}
+          {appStatus && (
+            <View style={styles.statusRow}>
+              <Text
+                style={[
+                  styles.statusChip,
+                  appStatus === "accepted"
+                    ? styles.statusAccepted
+                    : appStatus === "declined"
+                    ? styles.statusDeclined
+                    : styles.statusPending,
+                ]}
+              >
+                {appStatus === "pending" ? "Application pending" : `Application ${appStatus}`}
+              </Text>
+            </View>
+          )}
+
+          <FlatList
+            ref={listRef}
+            data={displayMessages}
+            keyExtractor={keyExtractor}
+            renderItem={renderItem}
+            contentContainerStyle={{
+              padding: 12,
+              paddingBottom: composerHeight + Math.max(0, insets.bottom),
+            }}
+            onScrollBeginDrag={Keyboard.dismiss}
+            keyboardDismissMode={Platform.OS === "ios" ? "interactive" : "on-drag"}
+            keyboardShouldPersistTaps="handled"
+            ListEmptyComponent={
+              <View style={{ padding: 24 }}>
+                <Text style={{ color: "#666" }}>No messages yet. Say hi 👋</Text>
+              </View>
+            }
+          />
+
+          {/* Composer */}
+          <View
+            onLayout={onComposerLayout}
+            style={[styles.composerWrap, { paddingBottom: Math.max(0, insets.bottom * 0.1) }]}
+            {...panKeyboardResponder.panHandlers}
+          >
+            <View style={styles.inputRow}>
+              <TextInput
+                value={input}
+                onChangeText={setInput}
+                placeholder="Type a message"
+                placeholderTextColor="#999"
+                style={styles.input}
+                multiline
+                autoCapitalize="sentences"
+                returnKeyType="send"
+                onSubmitEditing={onSend}
+              />
+              <Pressable onPress={onSend} style={({ pressed }) => [styles.sendBtn, pressed && { opacity: 0.7 }]}>
+                <Text style={styles.sendLabel}>Send</Text>
+              </Pressable>
+            </View>
+          </View>
+        </Animated.View>
+      </KeyboardAvoidingView>
+    </>
   );
 }
 
 const styles = StyleSheet.create({
+  flex: { flex: 1 },
+  container: { flex: 1, backgroundColor: "#fff" },
+
+  header: {
+    paddingHorizontal: 12,
+    paddingBottom: 8,
+    borderBottomWidth: StyleSheet.hairlineWidth,
+    borderBottomColor: "#EAEAEA",
+    backgroundColor: "#fff",
+    flexDirection: "row",
+    alignItems: "center",
+    gap: 8,
+  },
+  headerBack: { fontSize: 26, lineHeight: 26, color: "#6B7280", paddingRight: 6 },
+  headerTitle: { flex: 1, fontSize: 18, fontWeight: "600", color: "#111" },
+
+  statusRow: {
+    paddingHorizontal: 12,
+    paddingVertical: 8,
+    backgroundColor: "#fff",
+    borderBottomColor: "#F1F2F4",
+    borderBottomWidth: StyleSheet.hairlineWidth,
+  },
+  statusChip: {
+    alignSelf: "flex-start",
+    paddingHorizontal: 10,
+    paddingVertical: 5,
+    borderRadius: 999,
+    fontSize: 12,
+    overflow: "hidden",
+  },
+  statusPending: { backgroundColor: "#FFF4CC", color: "#8A6A00" },
+  statusAccepted: { backgroundColor: "#E9F9EE", color: "#1E7F3E" },
+  statusDeclined: { backgroundColor: "#FDE7E7", color: "#A03030" },
+
   row: {
     width: "100%",
     marginVertical: 4,
@@ -235,6 +584,7 @@ const styles = StyleSheet.create({
   },
   rowMine: { justifyContent: "flex-end" },
   rowTheirs: { justifyContent: "flex-start" },
+
   bubble: {
     maxWidth: "100%",
     minWidth: 60,
@@ -243,42 +593,58 @@ const styles = StyleSheet.create({
     borderRadius: 16,
   },
   bubbleMine: {
-    backgroundColor: "#1f6feb",
+    backgroundColor: Colors.primary,
     borderBottomRightRadius: 4,
   },
   bubbleTheirs: {
-    backgroundColor: "#F3F4F6",
+    backgroundColor: "#F0F1F3",
     borderBottomLeftRadius: 4,
   },
-  body: { fontSize: 16 },
-  meta: { fontSize: 11, marginTop: 4 },
-  metaMine: { color: "rgba(255,255,255,0.8)", textAlign: "right" },
-  metaTheirs: { color: "#6B7280" },
+
+  text: { fontSize: 16, lineHeight: 20 },
+  textMine: { color: "#fff" },
+  textTheirs: { color: "#111" },
+
+  time: { fontSize: 11, marginTop: 4 },
+  timeMine: { color: "rgba(255,255,255,0.8)", textAlign: "right" },
+  timeTheirs: { color: "#888" },
+
+  systemWrap: { width: "100%", alignItems: "center", marginVertical: 6 },
+  systemText: { fontSize: 12, color: "#777" },
+
   avatar: { width: 32, height: 32, borderRadius: 16, backgroundColor: "#E5E7EB" },
   silhouette: { alignItems: "center", justifyContent: "center" },
-  inputRow: {
-    flexDirection: "row",
-    padding: 10,
-    gap: 8,
-    borderTopWidth: 1,
-    borderColor: "#eee",
+
+  composerWrap: {
+    position: "absolute",
+    left: 0,
+    right: 0,
+    bottom: 0,
     backgroundColor: "#fff",
+    borderTopWidth: StyleSheet.hairlineWidth,
+    borderTopColor: "#E4E6EA",
+    paddingTop: 2,
+    paddingHorizontal: 10,
   },
+  inputRow: { flexDirection: "row", alignItems: "flex-end", gap: 8 },
   input: {
     flex: 1,
-    borderWidth: 1,
-    borderColor: "#e5e5e5",
-    borderRadius: 10,
+    minHeight: 38,
+    maxHeight: 120,
+    borderWidth: StyleSheet.hairlineWidth,
+    borderColor: "#D9DCE1",
+    borderRadius: 12,
     paddingHorizontal: 12,
-    paddingVertical: 10,
-    backgroundColor: "#fff",
+    paddingVertical: 6,
+    fontSize: 16,
   },
-  send: {
-    backgroundColor: "#1f6feb",
-    paddingHorizontal: 16,
-    borderRadius: 10,
+  sendBtn: {
+    height: 38,
+    paddingHorizontal: 14,
+    borderRadius: 12,
     alignItems: "center",
     justifyContent: "center",
+    backgroundColor: Colors.primary,
   },
+  sendLabel: { color: "#fff", fontWeight: "600", fontSize: 15 },
 });
-

--- a/mobile/app/(client)/profile.tsx
+++ b/mobile/app/(client)/profile.tsx
@@ -3,11 +3,26 @@ import TopBar from "@src/components/TopBar";
 import { Colors } from "@src/theme/tokens";
 import { Ionicons } from "@expo/vector-icons";
 import { useAuth } from "@src/store/useAuth";
+import { useProfile } from "@src/store/useProfile";
+import React, { useEffect } from "react";
 import { router } from "expo-router";
 
 export default function ClientProfile() {
-  const { signOut, user } = useAuth();
-  const name = user?.username || "Your name";
+  const { signOut, user, token } = useAuth();
+  const userId = user?.id ?? 0;
+
+  const profiles = useProfile((s) => s.profiles);
+  const ensureProfile = useProfile((s) => s.ensureProfile);
+
+  useEffect(() => {
+    if (user) {
+      ensureProfile(user.id, user.username ?? "You", "client", token ?? undefined);
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [user?.id]);
+
+  const avatarUri = profiles[userId]?.avatarUri;
+  const name = profiles[userId]?.name || user?.username || "Your name";
 
   const confirmLogout = () => {
     Alert.alert("Log out", "Are you sure you want to log out?", [
@@ -20,21 +35,26 @@ export default function ClientProfile() {
     <View style={{ flex:1, backgroundColor:"#fff" }}>
       <TopBar />
       <View style={{ padding:12, gap:12 }}>
-        <View style={styles.profileCard}>
-          <Image source={require("../../assets/images/avatar.png")} style={styles.avatar} />
+        {/* Show profile tile */}
+        <Pressable
+          onPress={() => router.push("/(client)/profileDetails")}
+          style={styles.profileCard}
+          accessibilityRole="button"
+          hitSlop={{ top: 8, bottom: 8, left: 8, right: 8 }}
+        >
+          {avatarUri ? (
+            <Image source={{ uri: avatarUri }} style={styles.avatar} />
+          ) : (
+            <View style={[styles.avatar, styles.avatarSilhouette]}>
+              <Ionicons name="person" size={24} color="#9CA3AF" />
+            </View>
+          )}
           <View style={{ flex:1 }}>
             <Text style={styles.name}>{name}</Text>
             <Text style={styles.sub}>Show profile</Text>
           </View>
-        </View>
-
-        <View style={styles.switchCard}>
-          <View style={{ flex:1 }}>
-            <Text style={styles.switchTitle}>Switch to contractor</Text>
-            <Text style={styles.switchSub}>Simple and easy, switch today to start employing</Text>
-          </View>
-          <Ionicons name="business-outline" size={28} color="#6B7280" />
-        </View>
+          <Ionicons name="chevron-forward" size={20} color="#9CA3AF" />
+        </Pressable>
 
         <MenuItem icon="person-outline" label="Personal information" />
         <MenuItem icon="sync-outline" label="Subscriptions" />
@@ -50,25 +70,31 @@ export default function ClientProfile() {
   );
 }
 
-function MenuItem({ icon, label, last }:{ icon: keyof typeof Ionicons.glyphMap; label:string; last?: boolean }) {
+function MenuItem({ icon, label, last, onPress }:{ icon: keyof typeof Ionicons.glyphMap; label:string; last?: boolean; onPress?: () => void }) {
   return (
-    <View style={[styles.item, last && { borderBottomWidth: 0 }]}>
+    <Pressable
+      onPress={onPress}
+      accessibilityRole="button"
+      hitSlop={{ top: 8, bottom: 8, left: 8, right: 8 }}
+      style={({ pressed }) => [
+        styles.item,
+        last && { borderBottomWidth: 0 },
+        pressed && { opacity: 0.6 },
+      ]}
+    >
       <Ionicons name={icon} size={22} color="#111" />
       <Text style={styles.itemLabel}>{label}</Text>
       <Ionicons name="chevron-forward" size={20} color="#9CA3AF" />
-    </View>
+    </Pressable>
   );
 }
 
 const styles = StyleSheet.create({
   profileCard:{ backgroundColor:"#fff", borderRadius:12, borderWidth:1, borderColor: Colors.border, padding:12, flexDirection:"row", alignItems:"center", gap:12 },
-  avatar:{ width:48, height:48, borderRadius:24 },
+  avatar:{ width:48, height:48, borderRadius:24, backgroundColor:"#E5E7EB" },
+  avatarSilhouette:{ alignItems:"center", justifyContent:"center" },
   name:{ fontSize:16, fontWeight:"700" },
   sub:{ color: "#6B7280", marginTop:2 },
-  switchCard:{ backgroundColor:"#fff", borderRadius:12, borderWidth:1, borderColor: Colors.border, padding:12, flexDirection:"row", alignItems:"center", gap:12,
-               shadowColor:"#000", shadowOpacity:0.05, shadowRadius:4, shadowOffset:{ width:0, height:2 } },
-  switchTitle:{ fontWeight:"700", marginBottom:4 },
-  switchSub:{ color:"#6B7280" },
   item:{ borderBottomWidth:1, borderColor: Colors.border, paddingVertical:14, flexDirection:"row", alignItems:"center", gap:12 },
   itemLabel:{ flex:1, fontSize:16 },
   logout:{ color:"#111827", textDecorationLine:"underline", marginTop:10 }

--- a/mobile/app/(client)/profileDetails.tsx
+++ b/mobile/app/(client)/profileDetails.tsx
@@ -1,0 +1,528 @@
+import React, { useEffect, useState } from "react";
+import {
+  View,
+  Text,
+  StyleSheet,
+  ScrollView,
+  Image,
+  Pressable,
+  TextInput,
+  KeyboardAvoidingView,
+  Platform,
+} from "react-native";
+import { Stack, router } from "expo-router";
+import * as ImagePicker from "expo-image-picker";
+import { Ionicons } from "@expo/vector-icons";
+import { Colors } from "@src/theme/tokens";
+import { useAuth } from "@src/store/useAuth";
+import { useProfile } from "@src/store/useProfile";
+import { uploadAvatar, uploadBanner } from "@src/lib/api";
+import { useSafeAreaInsets } from "react-native-safe-area-context";
+
+const BACK_TO = "/(client)/profile";
+
+export default function ClientProfileDetails() {
+  const insets = useSafeAreaInsets();
+  const { user, token } = useAuth();
+  const userId = user?.id ?? 0;
+
+  const profiles = useProfile((s) => s.profiles);
+  const ensureProfile = useProfile((s) => s.ensureProfile);
+  const updateProfile = useProfile((s) => s.updateProfile);
+  const addSkill = useProfile((s) => s.addSkill);
+  const removeSkill = useProfile((s) => s.removeSkill);
+  const addInterest = useProfile((s) => s.addInterest);
+  const removeInterest = useProfile((s) => s.removeInterest);
+  const addQualification = useProfile((s) => s.addQualification);
+  const updateQualification = useProfile((s) => s.updateQualification);
+  const removeQualification = useProfile((s) => s.removeQualification);
+
+  useEffect(() => {
+    if (user) {
+      ensureProfile(user.id, user.username ?? "You", "client", token ?? undefined);
+    }
+  }, [user, ensureProfile, token]);
+
+  const profile = profiles[userId];
+
+  const [editing, setEditing] = useState(false);
+  const [name, setName] = useState(profile?.name ?? user?.username ?? "You");
+  const [headline, setHeadline] = useState(profile?.headline ?? "Hiring now");
+  const [location, setLocation] = useState(profile?.location ?? "London, UK");
+  const [company, setCompany] = useState(profile?.company ?? "");
+  const [bio, setBio] = useState(profile?.bio ?? "");
+
+  const [newSkill, setNewSkill] = useState("");
+  const [newInterest, setNewInterest] = useState("");
+
+  useEffect(() => {
+    if (profile) {
+      setName(profile.name);
+      setHeadline(profile.headline ?? "Hiring now");
+      setLocation(profile.location ?? "");
+      setCompany(profile.company ?? "");
+      setBio(profile.bio ?? "");
+    }
+  }, [profile]);
+
+  const save = () => {
+    if (!user) return;
+    updateProfile(
+      user.id,
+      {
+        name: name.trim(),
+        headline: headline.trim(),
+        location: location.trim(),
+        company: company.trim() || undefined,
+        bio: bio.trim() || undefined,
+      },
+      token ?? undefined
+    );
+    setEditing(false);
+  };
+
+  const pickImage = async (field: "avatarUri" | "bannerUri") => {
+    const res = await ImagePicker.launchImageLibraryAsync({
+      allowsEditing: true,
+      quality: 0.8,
+      mediaTypes: ImagePicker.MediaTypeOptions.Images,
+    });
+    if (!res.canceled && res.assets?.length) {
+      const localUri = res.assets[0].uri;
+      updateProfile(userId, { [field]: localUri } as any);
+      if (token) {
+        try {
+          const url =
+            field === "avatarUri"
+              ? await uploadAvatar(userId, localUri, token)
+              : await uploadBanner(userId, localUri, token);
+          updateProfile(userId, { [field]: url } as any);
+        } catch (err) {
+          console.warn(err);
+        }
+      }
+    }
+  };
+
+  const pickImageForQual = async (id: string) => {
+    const res = await ImagePicker.launchImageLibraryAsync({
+      allowsEditing: true,
+      quality: 0.8,
+      mediaTypes: ImagePicker.MediaTypeOptions.Images,
+    });
+    if (!res.canceled && res.assets?.length) {
+      updateQualification(userId, id, { imageUri: res.assets[0].uri }, token ?? undefined);
+    }
+  };
+
+  const addQual = () => {
+    addQualification(
+      userId,
+      {
+        id: String(Date.now()),
+        title: "New Qualification",
+        status: "pending",
+      },
+      token ?? undefined
+    );
+  };
+
+  if (!profile) {
+    return (
+      <View style={{ flex: 1, alignItems: "center", justifyContent: "center" }}>
+        <Text>Loading profile…</Text>
+      </View>
+    );
+  }
+
+  const hasBio = !!profile.bio?.trim();
+  const hasCompany = !!profile.company?.toString().trim();
+  const hasLocation = !!profile.location?.toString().trim();
+  const showHeadlineRow = !!profile.headline?.trim();
+
+  return (
+    <>
+      <Stack.Screen options={{ headerShown: false }} />
+      <KeyboardAvoidingView
+        style={{ flex: 1, backgroundColor: "#fff" }}
+        behavior={Platform.OS === "ios" ? "padding" : undefined}
+        keyboardVerticalOffset={Platform.OS === "ios" ? insets.top : 0}
+      >
+        <View style={{ flex: 1 }}>
+          {/* Top bar */}
+          <View style={[styles.topBar, { paddingTop: insets.top + 6 }]}>
+            <Pressable onPress={() => router.replace(BACK_TO)} hitSlop={12}>
+              <Ionicons name="chevron-back" size={24} color="#111" />
+            </Pressable>
+
+            <Text style={styles.topTitle}>Profile</Text>
+
+            <Pressable onPress={() => setEditing((e) => !e)} hitSlop={12}>
+              <Ionicons name={editing ? "close" : "pencil"} size={22} color="#6B7280" />
+            </Pressable>
+          </View>
+
+          <ScrollView
+            contentContainerStyle={{ paddingBottom: Math.max(insets.bottom, 16) + 24 }}
+            keyboardShouldPersistTaps="handled"
+          >
+            {/* Banner */}
+            <Pressable onPress={() => editing && pickImage("bannerUri")} disabled={!editing}>
+              <Image
+                source={{
+                  uri:
+                    profile.bannerUri ??
+                    "https://images.unsplash.com/photo-1503264116251-35a269479413?q=80&w=1200&auto=format&fit=crop",
+                }}
+                style={styles.banner}
+              />
+            </Pressable>
+
+            {/* Avatar */}
+            <View style={styles.avatarWrap}>
+              <Pressable onPress={() => editing && pickImage("avatarUri")} disabled={!editing}>
+                {profile.avatarUri ? (
+                  <Image source={{ uri: profile.avatarUri }} style={styles.avatar} />
+                ) : (
+                  <View
+                    style={[
+                      styles.avatar,
+                      { alignItems: "center", justifyContent: "center", backgroundColor: "#E5E7EB" },
+                    ]}
+                  >
+                    <Ionicons name="person" size={28} color="#9CA3AF" />
+                  </View>
+                )}
+              </Pressable>
+            </View>
+
+            {/* Identity */}
+            <View style={styles.card}>
+              {editing ? (
+                <>
+                  <TextInput value={name} onChangeText={setName} style={styles.input} placeholder="Name" />
+                  <TextInput value={headline} onChangeText={setHeadline} style={styles.input} placeholder="Headline" />
+                </>
+              ) : (
+                <>
+                  <Text style={styles.name}>{profile.name}</Text>
+                  {showHeadlineRow && (
+                    <View style={styles.rowCenter}>
+                      <Text style={styles.headline}>{profile.headline}</Text>
+                      <View style={styles.dotOnline} />
+                    </View>
+                  )}
+                </>
+              )}
+
+              <View style={styles.metaGrid}>
+                <Meta icon="location-outline" label="Based in" value={!editing && hasLocation ? profile.location : undefined} />
+                <Meta icon="business-outline" label="Company" value={!editing && hasCompany ? profile.company : undefined} />
+                <Meta icon="construct-outline" label="Jobs Completed" value={String(profile.jobsCompleted ?? 0)} />
+                <Meta icon="person-outline" label="Role" value="Client" />
+              </View>
+
+              {editing && (
+                <>
+                  <TextInput value={location} onChangeText={setLocation} style={styles.input} placeholder="Location" />
+                  <TextInput value={company} onChangeText={setCompany} style={styles.input} placeholder="Company" />
+                </>
+              )}
+            </View>
+
+            {/* About */}
+            {(editing || hasBio) && (
+              <View style={styles.card}>
+                <Text style={styles.sectionTitle}>About</Text>
+                {editing ? (
+                  <TextInput
+                    multiline
+                    value={bio}
+                    onChangeText={setBio}
+                    style={[styles.input, { minHeight: 100, textAlignVertical: "top" }]}
+                    placeholder="Tell people about yourself"
+                  />
+                ) : (
+                  <Text style={styles.bodyText}>{profile.bio}</Text>
+                )}
+              </View>
+            )}
+
+            {/* Qualifications */}
+            {(editing || profile.qualifications.length > 0) && (
+              <View style={styles.card}>
+                <View style={styles.rowBetween}>
+                  <Text style={styles.sectionTitle}>Qualifications</Text>
+                  {editing && (
+                    <Pressable onPress={addQual} style={[styles.btnSm, styles.btnGhost]}>
+                      <Ionicons name="add" size={18} />
+                      <Text style={styles.btnGhostText}>Add</Text>
+                    </Pressable>
+                  )}
+                </View>
+
+                {profile.qualifications.map((q) => (
+                  <View key={q.id} style={styles.qualRow}>
+                    <Pressable
+                      onPress={() => editing && pickImageForQual(q.id)}
+                      disabled={!editing}
+                      style={styles.qualImgWrap}
+                    >
+                      {q.imageUri ? (
+                        <Image source={{ uri: q.imageUri }} style={styles.qualImg} />
+                      ) : (
+                        <View style={[styles.qualImg, styles.qualPlaceholder]}>
+                          <Ionicons name="add" size={22} color="#6B7280" />
+                        </View>
+                      )}
+                    </Pressable>
+
+                    <View style={{ flex: 1 }}>
+                      {editing ? (
+                        <TextInput
+                          value={q.title}
+                          onChangeText={(t) =>
+                            updateQualification(userId, q.id, { title: t }, token ?? undefined)
+                          }
+                          style={styles.input}
+                          placeholder="Title"
+                        />
+                      ) : (
+                        <Text style={styles.qualTitle}>{q.title}</Text>
+                      )}
+                      <Text
+                        style={[
+                          styles.badge,
+                          q.status === "verified" ? styles.badgeVerified : styles.badgePending,
+                        ]}
+                      >
+                        {q.status === "verified" ? "Verified" : "Pending verification"}
+                      </Text>
+                    </View>
+
+                    {editing ? (
+                      <Pressable
+                        onPress={() => removeQualification(userId, q.id, token ?? undefined)}
+                        style={[styles.btnIcon, { borderColor: "#ef4444" }]}
+                        hitSlop={6}
+                      >
+                        <Ionicons name="trash" size={18} color="#ef4444" />
+                      </Pressable>
+                    ) : null}
+                  </View>
+                ))}
+              </View>
+            )}
+
+            {/* Skills */}
+            {(editing || profile.skills.length > 0) && (
+              <ChipsSection
+                title="Skills"
+                items={profile.skills}
+                editing={editing}
+                newValue={newSkill}
+                onChangeNew={setNewSkill}
+                onAdd={() => {
+                  if (!newSkill.trim()) return;
+                  addSkill(userId, newSkill.trim(), token ?? undefined);
+                  setNewSkill("");
+                }}
+                onRemove={(s) => removeSkill(userId, s, token ?? undefined)}
+              />
+            )}
+
+            {/* Interests */}
+            {(editing || profile.interests.length > 0) && (
+              <ChipsSection
+                title="Interests"
+                items={profile.interests}
+                editing={editing}
+                newValue={newInterest}
+                onChangeNew={setNewInterest}
+                onAdd={() => {
+                  if (!newInterest.trim()) return;
+                  addInterest(userId, newInterest.trim(), token ?? undefined);
+                  setNewInterest("");
+                }}
+                onRemove={(s) => removeInterest(userId, s, token ?? undefined)}
+              />
+            )}
+
+            {/* Save button */}
+            {editing && (
+              <View
+                style={{
+                  paddingHorizontal: 12,
+                  paddingTop: 8,
+                  paddingBottom: Math.max(insets.bottom, 8),
+                }}
+              >
+                <Pressable onPress={save} style={[styles.btn, styles.btnPrimary]}>
+                  <Text style={styles.btnPrimaryText}>Save changes</Text>
+                </Pressable>
+              </View>
+            )}
+          </ScrollView>
+        </View>
+      </KeyboardAvoidingView>
+    </>
+  );
+}
+
+function Meta({ icon, label, value }: { icon: any; label: string; value?: string }) {
+  if (!value) return null;
+  return (
+    <View style={styles.metaItem}>
+      <Ionicons name={icon} size={16} color="#6B7280" />
+      <Text style={styles.metaLabel}>{label}</Text>
+      <Text style={styles.metaValue}>{value}</Text>
+    </View>
+  );
+}
+
+function ChipsSection({
+  title,
+  items,
+  editing,
+  newValue,
+  onChangeNew,
+  onAdd,
+  onRemove,
+}: {
+  title: string;
+  items: string[];
+  editing: boolean;
+  newValue: string;
+  onChangeNew: (s: string) => void;
+  onAdd: () => void;
+  onRemove: (s: string) => void;
+}) {
+  return (
+    <View style={styles.card}>
+      <Text style={styles.sectionTitle}>{title}</Text>
+      <View style={{ flexDirection: "row", flexWrap: "wrap", gap: 8, marginTop: 8 }}>
+        {items.map((s) => (
+          <View key={s} style={styles.chip}>
+            <Text style={styles.chipText}>{s}</Text>
+            {editing && (
+              <Pressable onPress={() => onRemove(s)} hitSlop={6}>
+                <Ionicons name="close" size={14} color="#6B7280" />
+              </Pressable>
+            )}
+          </View>
+        ))}
+      </View>
+      {editing && (
+        <View style={{ flexDirection: "row", gap: 8, marginTop: 12 }}>
+          <TextInput
+            value={newValue}
+            onChangeText={onChangeNew}
+            placeholder={`Add ${title.slice(0, -1).toLowerCase()}`}
+            style={[styles.input, { flex: 1 }]}
+          />
+          <Pressable onPress={onAdd} style={[styles.btn, styles.btnGhost]}>
+            <Ionicons name="add" size={18} />
+            <Text style={styles.btnGhostText}>Add</Text>
+          </Pressable>
+        </View>
+      )}
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  topBar: {
+    paddingHorizontal: 12,
+    paddingBottom: 6,
+    borderBottomWidth: StyleSheet.hairlineWidth,
+    borderBottomColor: "#eee",
+    backgroundColor: "#fff",
+    flexDirection: "row",
+    alignItems: "center",
+    justifyContent: "space-between",
+  },
+  topTitle: { fontWeight: "800", fontSize: 18, color: "#1F2937" },
+
+  banner: { width: "100%", height: 140, backgroundColor: "#ddd" },
+  avatarWrap: { marginTop: -34, paddingHorizontal: 12, marginBottom: 6 },
+  avatar: { width: 68, height: 68, borderRadius: 34, borderWidth: 3, borderColor: "#fff" },
+
+  card: {
+    backgroundColor: "#fff",
+    borderRadius: 16,
+    marginHorizontal: 12,
+    marginTop: 10,
+    padding: 12,
+    borderWidth: StyleSheet.hairlineWidth,
+    borderColor: "#ececec",
+  },
+
+  name: { fontSize: 20, fontWeight: "800", color: "#111" },
+  headline: { color: "#374151", fontWeight: "600" },
+  rowCenter: { flexDirection: "row", alignItems: "center", gap: 8, marginTop: 2 },
+  dotOnline: { width: 10, height: 10, borderRadius: 5, backgroundColor: "#22c55e" },
+
+  metaGrid: { marginTop: 10, gap: 8 },
+  metaItem: { flexDirection: "row", alignItems: "center", gap: 6 },
+  metaLabel: { color: "#6B7280" },
+  metaValue: { color: "#111", fontWeight: "600" },
+
+  sectionTitle: { fontWeight: "800", fontSize: 16, color: "#1F2937" },
+  bodyText: { color: "#374151", lineHeight: 20 },
+
+  qualRow: { flexDirection: "row", alignItems: "center", gap: 10, marginTop: 10 },
+  qualImgWrap: { borderRadius: 8, overflow: "hidden" },
+  qualImg: { width: 110, height: 70, borderRadius: 8, backgroundColor: "#eee" },
+  qualPlaceholder: { alignItems: "center", justifyContent: "center" },
+  qualTitle: { fontWeight: "700", color: "#111", marginBottom: 4 },
+
+  chip: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: 6,
+    paddingVertical: 6,
+    paddingHorizontal: 10,
+    borderRadius: 999,
+    backgroundColor: "#F3F4F6",
+  },
+  chipText: { color: "#111", fontWeight: "600" },
+
+  input: {
+    borderWidth: StyleSheet.hairlineWidth,
+    borderColor: "#e5e7eb",
+    borderRadius: 10,
+    paddingHorizontal: 10,
+    paddingVertical: 10,
+    fontSize: 16,
+    backgroundColor: "#fff",
+  },
+  rowBetween: { flexDirection: "row", alignItems: "center", justifyContent: "space-between" },
+
+  btn: {
+    borderRadius: 12,
+    paddingVertical: 12,
+    paddingHorizontal: 14,
+    alignItems: "center",
+    justifyContent: "center",
+    flexDirection: "row",
+    gap: 6,
+  },
+  btnPrimary: { backgroundColor: Colors.primary },
+  btnPrimaryText: { color: "#fff", fontWeight: "800" },
+  btnGhost: { backgroundColor: "#fff", borderWidth: StyleSheet.hairlineWidth, borderColor: "#e5e7eb" },
+  btnGhostText: { fontWeight: "700", color: "#111" },
+  btnSm: { paddingVertical: 8, paddingHorizontal: 12, borderRadius: 10 },
+  btnIcon: { padding: 8, borderRadius: 10, borderWidth: StyleSheet.hairlineWidth, borderColor: "#e5e7eb" },
+
+  badge: {
+    alignSelf: "flex-start",
+    paddingHorizontal: 10,
+    paddingVertical: 5,
+    borderRadius: 999,
+    fontSize: 12,
+    overflow: "hidden",
+  },
+  badgeVerified: { backgroundColor: "#E9F9EE", color: "#1E7F3E" },
+  badgePending: { backgroundColor: "#FFF4CC", color: "#8A6A00" },
+});
+


### PR DESCRIPTION
## Summary
- add detailed profile screen for clients, matching manager/labourer UI
- remove switch-to-contractor block and allow clients to edit avatar/banner
- wire up client tabs with hidden profile details route
- match client chats to other roles, pinning Construction AI conversation at top
- enable full chat thread features for clients including AI replies and cross-role notifications

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68bb4eef2ef083209131ae283b71cef3