### PR TITLE
Enable client profile management and streamline chat UI

### DIFF
--- a/mobile/app/(client)/_layout.tsx
+++ b/mobile/app/(client)/_layout.tsx
@@ -2,9 +2,11 @@ import { Tabs, Redirect } from "expo-router";
 import { useAuth } from "@src/store/useAuth";
 import { Ionicons } from "@expo/vector-icons";
 import { Colors } from "@src/theme/tokens";
+import { useNotifications } from "@src/store/useNotifications";
 
 export default function ClientTabs() {
   const { signedIn } = useAuth();
+  const unread = useNotifications((s) => s.unread.client);
   if (!signedIn) return <Redirect href="/(auth)/welcome" />;
 
   return (
@@ -17,14 +19,18 @@ export default function ClientTabs() {
         tabBarIcon: ({ focused, size, color }) => {
           const name = (() => {
             switch (route.name) {
-              case "chats": return focused ? "chatbubbles" : "chatbubbles-outline";
-              case "projects/index": return focused ? "briefcase" : "briefcase-outline";
-              case "map": return focused ? "map" : "map-outline";
-              default: return "ellipse-outline";
+              case "chats":
+                return focused ? "chatbubbles" : "chatbubbles-outline";
+              case "projects/index":
+                return focused ? "briefcase" : "briefcase-outline";
+              case "map":
+                return focused ? "map" : "map-outline";
+              default:
+                return "ellipse-outline";
             }
           })();
           return <Ionicons name={name as any} size={size} color={color} />;
-        }
+        },
       })}
     >
       {/* hidden routes */}
@@ -32,9 +38,13 @@ export default function ClientTabs() {
       <Tabs.Screen name="projects/[id]" options={{ href: null }} />
       <Tabs.Screen name="chats/[id]" options={{ href: null }} />
       <Tabs.Screen name="profile" options={{ href: null }} />
+      <Tabs.Screen name="profileDetails" options={{ href: null }} />
 
       {/* visible tabs */}
-      <Tabs.Screen name="chats" options={{ title: "Chats" }} />
+      <Tabs.Screen
+        name="chats"
+        options={{ title: "Chats", tabBarBadge: unread > 0 ? unread : undefined }}
+      />
       <Tabs.Screen name="projects/index" options={{ title: "Projects" }} />
       <Tabs.Screen name="map" options={{ title: "Map" }} />
     </Tabs>

--- a/mobile/app/(client)/chats.tsx
+++ b/mobile/app/(client)/chats.tsx
@@ -1,58 +1,182 @@
-import { useEffect, useState } from "react";
-import { View, FlatList, Text, TextInput, Pressable, StyleSheet } from "react-native";
-import { listChats } from "@src/lib/api";
-import { router } from "expo-router";
+import { useEffect, useState, useCallback } from "react";
+import {
+  View,
+  FlatList,
+  Text,
+  Pressable,
+  StyleSheet,
+  Image,
+  Alert,
+} from "react-native";
 import TopBar from "@src/components/TopBar";
+import { listChats, type Chat, deleteChat } from "@src/lib/api";
+import { parseDate } from "@src/lib/date";
+import { useAuth } from "@src/store/useAuth";
+import { useFocusEffect, router } from "expo-router";
+import { useNotifications } from "@src/store/useNotifications";
+import { Ionicons } from "@expo/vector-icons";
+import { useProfile } from "@src/store/useProfile";
+import { useChatBadge } from "@src/store/useChatBadge";
+import { Swipeable } from "react-native-gesture-handler";
 
-export default function ClientChats() {
-  const [q, setQ] = useState("");
-  const [items, setItems] = useState<any[]>([]);
-  useEffect(() => { listChats().then(setItems); }, []);
-  const filtered = items.filter((t:any) =>
-    ((t.title ?? "") + " " + (t.lastMessage ?? "")).toLowerCase().includes(q.toLowerCase())
+export default function Chats() {
+  const { user } = useAuth();
+  const userId = user?.id ?? 0;
+  const [items, setItems] = useState<Chat[]>([]);
+  const { clear } = useNotifications();
+  const profiles = useProfile((s) => s.profiles);
+  const lastSeen = useChatBadge((s) => s.lastSeenByChat);
+
+  const load = useCallback(async () => {
+    const data = await listChats(user?.id);
+    setItems(Array.isArray(data) ? data.filter((c) => c.id !== 0) : []);
+  }, [user?.id]);
+
+  const handleDelete = (id: number) => {
+    Alert.alert("Delete chat?", "Are you sure you want to delete chat?", [
+      { text: "Cancel", style: "cancel" },
+      {
+        text: "Delete",
+        style: "destructive",
+        onPress: async () => {
+          setItems((prev) => prev.filter((c) => c.id !== id));
+          await deleteChat(id);
+        },
+      },
+    ]);
+  };
+
+  useFocusEffect(
+    useCallback(() => {
+      clear("client");
+      load();
+    }, [clear, load])
   );
 
+  useEffect(() => {
+    const t = setInterval(load, 5000);
+    return () => clearInterval(t);
+  }, [load]);
+
+  const renderRow = ({ item }: { item: Chat }) => {
+    const otherId =
+      item.memberIds?.find((id) => id !== userId) ??
+      (item.workerId === userId ? item.managerId : item.workerId);
+    const avatarUri = otherId ? profiles[otherId]?.avatarUri : undefined;
+    const seen = lastSeen[item.id];
+    const isUnread = item.lastTime
+      ? !seen || parseDate(seen) < parseDate(item.lastTime)
+      : false;
+
+    return (
+      <Swipeable
+        renderRightActions={() => (
+          <Pressable style={styles.delete} onPress={() => handleDelete(item.id)}>
+            <Ionicons name="trash" size={20} color="#fff" />
+            <Text style={styles.deleteText}>Delete</Text>
+          </Pressable>
+        )}
+      >
+        <Pressable
+          onPress={() => router.push(`/(client)/chats/${item.id}`)}
+          style={styles.row}
+        >
+          {avatarUri ? (
+            <Image source={{ uri: avatarUri }} style={styles.avatar} />
+          ) : (
+            <View style={[styles.avatar, styles.silhouette]}>
+              <Ionicons name="person" size={18} color="#9CA3AF" />
+            </View>
+          )}
+
+          <View style={{ flex: 1 }}>
+            <Text style={styles.title} numberOfLines={1}>
+              {item.title || "Chat"}
+            </Text>
+            {!!item.lastMessage && (
+              <Text style={styles.sub} numberOfLines={1}>
+                {item.lastMessage}
+              </Text>
+            )}
+          </View>
+
+          <View style={styles.right}>
+            {isUnread && <View style={styles.unread} />}
+            <Ionicons name="chevron-forward" size={18} color="#9CA3AF" />
+          </View>
+        </Pressable>
+      </Swipeable>
+    );
+  };
+
   return (
-    <View style={styles.container}>
+    <View style={{ flex: 1, backgroundColor: "#fff" }}>
       <TopBar />
-      <View style={{ padding:12 }}>
-        <TextInput placeholder="Search chats" value={q} onChangeText={setQ} style={styles.search} />
-        <FlatList
-          data={filtered}
-          keyExtractor={(i) => String(i.id)}
-          renderItem={({ item }) => {
-            const title: string = item.title ?? "Chat";
-            const initial = title.slice(0, 1).toUpperCase();
-            return (
-              <Pressable
-                style={styles.row}
-                onPress={() => router.push({ pathname: "/(client)/chats/[id]", params: { id: String(item.id) } })}
-              >
-                <View style={styles.avatar}><Text style={styles.avatarText}>{initial}</Text></View>
-                <View style={{ flex: 1 }}>
-                  <Text style={styles.name}>{title}</Text>
-                  <Text numberOfLines={1} style={styles.preview}>{item.lastMessage ?? ""}</Text>
-                </View>
-                <Text style={styles.time}>{item.lastTime ?? ""}</Text>
-              </Pressable>
-            );
-          }}
-          ItemSeparatorComponent={() => <View style={styles.sep} />}
-        />
-      </View>
+      <FlatList
+        data={items}
+        keyExtractor={(c) => String(c.id)}
+        renderItem={renderRow}
+        ItemSeparatorComponent={() => <View style={{ height: 8 }} />}
+        contentContainerStyle={{ padding: 12, flexGrow: 1 }}
+        ListEmptyComponent={
+          <View style={styles.emptyWrap}>
+            <View style={styles.emptyBadge}>
+              <Ionicons name="chatbubbles-outline" size={22} color="#6B7280" />
+            </View>
+            <Text style={styles.emptyTitle}>No chats yet</Text>
+            <Text style={styles.emptyText}>
+              Start a project or message a manager to start a conversation.
+            </Text>
+          </View>
+        }
+      />
     </View>
   );
 }
 
 const styles = StyleSheet.create({
-  container:{ flex:1, backgroundColor:"#fff" },
-  search:{ borderWidth:1, borderColor:"#e5e5e5", borderRadius:12, padding:10, marginBottom:8 },
-  row:{ flexDirection:"row", alignItems:"center", paddingVertical:10 },
-  avatar:{ width:40, height:40, borderRadius:20, alignItems:"center", justifyContent:"center",
-           borderWidth:1, borderColor:"#eee", marginRight:12, backgroundColor:"#f6f8fa" },
-  avatarText:{ fontWeight:"700" },
-  name:{ fontWeight:"600" },
-  preview:{ color:"#666", marginTop:2 },
-  time:{ color:"#999", marginLeft:8 },
-  sep:{ height:1, backgroundColor:"#f0f0f0" }
+  row: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: 10,
+    padding: 12,
+    borderWidth: 1,
+    borderColor: "#eee",
+    borderRadius: 12,
+    backgroundColor: "#fff",
+  },
+  delete: {
+    backgroundColor: "#EF4444",
+    justifyContent: "center",
+    alignItems: "center",
+    width: 72,
+    borderRadius: 12,
+    marginLeft: 8,
+  },
+  deleteText: { color: "#fff", fontWeight: "600", marginTop: 4 },
+  avatar: { width: 44, height: 44, borderRadius: 22, backgroundColor: "#E5E7EB" },
+  silhouette: { alignItems: "center", justifyContent: "center" },
+  title: { fontWeight: "700", color: "#1F2937" },
+  sub: { color: "#6B7280", marginTop: 2 },
+
+  right: { flexDirection: "row", alignItems: "center", gap: 6 },
+  unread: { width: 10, height: 10, borderRadius: 5, backgroundColor: "#16A34A" },
+
+  emptyWrap: {
+    flex: 1,
+    alignItems: "center",
+    justifyContent: "center",
+    paddingHorizontal: 24,
+  },
+  emptyBadge: {
+    width: 52,
+    height: 52,
+    borderRadius: 26,
+    backgroundColor: "#F3F4F6",
+    alignItems: "center",
+    justifyContent: "center",
+    marginBottom: 10,
+  },
+  emptyTitle: { fontSize: 16, fontWeight: "800", color: "#111827" },
+  emptyText: { marginTop: 6, color: "#6B7280", textAlign: "center" },
 });

--- a/mobile/app/(client)/profile.tsx
+++ b/mobile/app/(client)/profile.tsx
@@ -3,11 +3,26 @@ import TopBar from "@src/components/TopBar";
 import { Colors } from "@src/theme/tokens";
 import { Ionicons } from "@expo/vector-icons";
 import { useAuth } from "@src/store/useAuth";
+import { useProfile } from "@src/store/useProfile";
+import React, { useEffect } from "react";
 import { router } from "expo-router";
 
 export default function ClientProfile() {
-  const { signOut, user } = useAuth();
-  const name = user?.username || "Your name";
+  const { signOut, user, token } = useAuth();
+  const userId = user?.id ?? 0;
+
+  const profiles = useProfile((s) => s.profiles);
+  const ensureProfile = useProfile((s) => s.ensureProfile);
+
+  useEffect(() => {
+    if (user) {
+      ensureProfile(user.id, user.username ?? "You", "client", token ?? undefined);
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [user?.id]);
+
+  const avatarUri = profiles[userId]?.avatarUri;
+  const name = profiles[userId]?.name || user?.username || "Your name";
 
   const confirmLogout = () => {
     Alert.alert("Log out", "Are you sure you want to log out?", [
@@ -20,21 +35,26 @@ export default function ClientProfile() {
     <View style={{ flex:1, backgroundColor:"#fff" }}>
       <TopBar />
       <View style={{ padding:12, gap:12 }}>
-        <View style={styles.profileCard}>
-          <Image source={require("../../assets/images/avatar.png")} style={styles.avatar} />
+        {/* Show profile tile */}
+        <Pressable
+          onPress={() => router.push("/(client)/profileDetails")}
+          style={styles.profileCard}
+          accessibilityRole="button"
+          hitSlop={{ top: 8, bottom: 8, left: 8, right: 8 }}
+        >
+          {avatarUri ? (
+            <Image source={{ uri: avatarUri }} style={styles.avatar} />
+          ) : (
+            <View style={[styles.avatar, styles.avatarSilhouette]}>
+              <Ionicons name="person" size={24} color="#9CA3AF" />
+            </View>
+          )}
           <View style={{ flex:1 }}>
             <Text style={styles.name}>{name}</Text>
             <Text style={styles.sub}>Show profile</Text>
           </View>
-        </View>
-
-        <View style={styles.switchCard}>
-          <View style={{ flex:1 }}>
-            <Text style={styles.switchTitle}>Switch to contractor</Text>
-            <Text style={styles.switchSub}>Simple and easy, switch today to start employing</Text>
-          </View>
-          <Ionicons name="business-outline" size={28} color="#6B7280" />
-        </View>
+          <Ionicons name="chevron-forward" size={20} color="#9CA3AF" />
+        </Pressable>
 
         <MenuItem icon="person-outline" label="Personal information" />
         <MenuItem icon="sync-outline" label="Subscriptions" />
@@ -50,25 +70,31 @@ export default function ClientProfile() {
   );
 }
 
-function MenuItem({ icon, label, last }:{ icon: keyof typeof Ionicons.glyphMap; label:string; last?: boolean }) {
+function MenuItem({ icon, label, last, onPress }:{ icon: keyof typeof Ionicons.glyphMap; label:string; last?: boolean; onPress?: () => void }) {
   return (
-    <View style={[styles.item, last && { borderBottomWidth: 0 }]}>
+    <Pressable
+      onPress={onPress}
+      accessibilityRole="button"
+      hitSlop={{ top: 8, bottom: 8, left: 8, right: 8 }}
+      style={({ pressed }) => [
+        styles.item,
+        last && { borderBottomWidth: 0 },
+        pressed && { opacity: 0.6 },
+      ]}
+    >
       <Ionicons name={icon} size={22} color="#111" />
       <Text style={styles.itemLabel}>{label}</Text>
       <Ionicons name="chevron-forward" size={20} color="#9CA3AF" />
-    </View>
+    </Pressable>
   );
 }
 
 const styles = StyleSheet.create({
   profileCard:{ backgroundColor:"#fff", borderRadius:12, borderWidth:1, borderColor: Colors.border, padding:12, flexDirection:"row", alignItems:"center", gap:12 },
-  avatar:{ width:48, height:48, borderRadius:24 },
+  avatar:{ width:48, height:48, borderRadius:24, backgroundColor:"#E5E7EB" },
+  avatarSilhouette:{ alignItems:"center", justifyContent:"center" },
   name:{ fontSize:16, fontWeight:"700" },
   sub:{ color: "#6B7280", marginTop:2 },
-  switchCard:{ backgroundColor:"#fff", borderRadius:12, borderWidth:1, borderColor: Colors.border, padding:12, flexDirection:"row", alignItems:"center", gap:12,
-               shadowColor:"#000", shadowOpacity:0.05, shadowRadius:4, shadowOffset:{ width:0, height:2 } },
-  switchTitle:{ fontWeight:"700", marginBottom:4 },
-  switchSub:{ color:"#6B7280" },
   item:{ borderBottomWidth:1, borderColor: Colors.border, paddingVertical:14, flexDirection:"row", alignItems:"center", gap:12 },
   itemLabel:{ flex:1, fontSize:16 },
   logout:{ color:"#111827", textDecorationLine:"underline", marginTop:10 }

--- a/mobile/app/(client)/profileDetails.tsx
+++ b/mobile/app/(client)/profileDetails.tsx
@@ -1,0 +1,528 @@
+import React, { useEffect, useState } from "react";
+import {
+  View,
+  Text,
+  StyleSheet,
+  ScrollView,
+  Image,
+  Pressable,
+  TextInput,
+  KeyboardAvoidingView,
+  Platform,
+} from "react-native";
+import { Stack, router } from "expo-router";
+import * as ImagePicker from "expo-image-picker";
+import { Ionicons } from "@expo/vector-icons";
+import { Colors } from "@src/theme/tokens";
+import { useAuth } from "@src/store/useAuth";
+import { useProfile } from "@src/store/useProfile";
+import { uploadAvatar, uploadBanner } from "@src/lib/api";
+import { useSafeAreaInsets } from "react-native-safe-area-context";
+
+const BACK_TO = "/(client)/profile";
+
+export default function ClientProfileDetails() {
+  const insets = useSafeAreaInsets();
+  const { user, token } = useAuth();
+  const userId = user?.id ?? 0;
+
+  const profiles = useProfile((s) => s.profiles);
+  const ensureProfile = useProfile((s) => s.ensureProfile);
+  const updateProfile = useProfile((s) => s.updateProfile);
+  const addSkill = useProfile((s) => s.addSkill);
+  const removeSkill = useProfile((s) => s.removeSkill);
+  const addInterest = useProfile((s) => s.addInterest);
+  const removeInterest = useProfile((s) => s.removeInterest);
+  const addQualification = useProfile((s) => s.addQualification);
+  const updateQualification = useProfile((s) => s.updateQualification);
+  const removeQualification = useProfile((s) => s.removeQualification);
+
+  useEffect(() => {
+    if (user) {
+      ensureProfile(user.id, user.username ?? "You", "client", token ?? undefined);
+    }
+  }, [user, ensureProfile, token]);
+
+  const profile = profiles[userId];
+
+  const [editing, setEditing] = useState(false);
+  const [name, setName] = useState(profile?.name ?? user?.username ?? "You");
+  const [headline, setHeadline] = useState(profile?.headline ?? "Hiring now");
+  const [location, setLocation] = useState(profile?.location ?? "London, UK");
+  const [company, setCompany] = useState(profile?.company ?? "");
+  const [bio, setBio] = useState(profile?.bio ?? "");
+
+  const [newSkill, setNewSkill] = useState("");
+  const [newInterest, setNewInterest] = useState("");
+
+  useEffect(() => {
+    if (profile) {
+      setName(profile.name);
+      setHeadline(profile.headline ?? "Hiring now");
+      setLocation(profile.location ?? "");
+      setCompany(profile.company ?? "");
+      setBio(profile.bio ?? "");
+    }
+  }, [profile]);
+
+  const save = () => {
+    if (!user) return;
+    updateProfile(
+      user.id,
+      {
+        name: name.trim(),
+        headline: headline.trim(),
+        location: location.trim(),
+        company: company.trim() || undefined,
+        bio: bio.trim() || undefined,
+      },
+      token ?? undefined
+    );
+    setEditing(false);
+  };
+
+  const pickImage = async (field: "avatarUri" | "bannerUri") => {
+    const res = await ImagePicker.launchImageLibraryAsync({
+      allowsEditing: true,
+      quality: 0.8,
+      mediaTypes: ImagePicker.MediaTypeOptions.Images,
+    });
+    if (!res.canceled && res.assets?.length) {
+      const localUri = res.assets[0].uri;
+      updateProfile(userId, { [field]: localUri } as any);
+      if (token) {
+        try {
+          const url =
+            field === "avatarUri"
+              ? await uploadAvatar(userId, localUri, token)
+              : await uploadBanner(userId, localUri, token);
+          updateProfile(userId, { [field]: url } as any);
+        } catch (err) {
+          console.warn(err);
+        }
+      }
+    }
+  };
+
+  const pickImageForQual = async (id: string) => {
+    const res = await ImagePicker.launchImageLibraryAsync({
+      allowsEditing: true,
+      quality: 0.8,
+      mediaTypes: ImagePicker.MediaTypeOptions.Images,
+    });
+    if (!res.canceled && res.assets?.length) {
+      updateQualification(userId, id, { imageUri: res.assets[0].uri }, token ?? undefined);
+    }
+  };
+
+  const addQual = () => {
+    addQualification(
+      userId,
+      {
+        id: String(Date.now()),
+        title: "New Qualification",
+        status: "pending",
+      },
+      token ?? undefined
+    );
+  };
+
+  if (!profile) {
+    return (
+      <View style={{ flex: 1, alignItems: "center", justifyContent: "center" }}>
+        <Text>Loading profile…</Text>
+      </View>
+    );
+  }
+
+  const hasBio = !!profile.bio?.trim();
+  const hasCompany = !!profile.company?.toString().trim();
+  const hasLocation = !!profile.location?.toString().trim();
+  const showHeadlineRow = !!profile.headline?.trim();
+
+  return (
+    <>
+      <Stack.Screen options={{ headerShown: false }} />
+      <KeyboardAvoidingView
+        style={{ flex: 1, backgroundColor: "#fff" }}
+        behavior={Platform.OS === "ios" ? "padding" : undefined}
+        keyboardVerticalOffset={Platform.OS === "ios" ? insets.top : 0}
+      >
+        <View style={{ flex: 1 }}>
+          {/* Top bar */}
+          <View style={[styles.topBar, { paddingTop: insets.top + 6 }]}>
+            <Pressable onPress={() => router.replace(BACK_TO)} hitSlop={12}>
+              <Ionicons name="chevron-back" size={24} color="#111" />
+            </Pressable>
+
+            <Text style={styles.topTitle}>Profile</Text>
+
+            <Pressable onPress={() => setEditing((e) => !e)} hitSlop={12}>
+              <Ionicons name={editing ? "close" : "pencil"} size={22} color="#6B7280" />
+            </Pressable>
+          </View>
+
+          <ScrollView
+            contentContainerStyle={{ paddingBottom: Math.max(insets.bottom, 16) + 24 }}
+            keyboardShouldPersistTaps="handled"
+          >
+            {/* Banner */}
+            <Pressable onPress={() => editing && pickImage("bannerUri")} disabled={!editing}>
+              <Image
+                source={{
+                  uri:
+                    profile.bannerUri ??
+                    "https://images.unsplash.com/photo-1503264116251-35a269479413?q=80&w=1200&auto=format&fit=crop",
+                }}
+                style={styles.banner}
+              />
+            </Pressable>
+
+            {/* Avatar */}
+            <View style={styles.avatarWrap}>
+              <Pressable onPress={() => editing && pickImage("avatarUri")} disabled={!editing}>
+                {profile.avatarUri ? (
+                  <Image source={{ uri: profile.avatarUri }} style={styles.avatar} />
+                ) : (
+                  <View
+                    style={[
+                      styles.avatar,
+                      { alignItems: "center", justifyContent: "center", backgroundColor: "#E5E7EB" },
+                    ]}
+                  >
+                    <Ionicons name="person" size={28} color="#9CA3AF" />
+                  </View>
+                )}
+              </Pressable>
+            </View>
+
+            {/* Identity */}
+            <View style={styles.card}>
+              {editing ? (
+                <>
+                  <TextInput value={name} onChangeText={setName} style={styles.input} placeholder="Name" />
+                  <TextInput value={headline} onChangeText={setHeadline} style={styles.input} placeholder="Headline" />
+                </>
+              ) : (
+                <>
+                  <Text style={styles.name}>{profile.name}</Text>
+                  {showHeadlineRow && (
+                    <View style={styles.rowCenter}>
+                      <Text style={styles.headline}>{profile.headline}</Text>
+                      <View style={styles.dotOnline} />
+                    </View>
+                  )}
+                </>
+              )}
+
+              <View style={styles.metaGrid}>
+                <Meta icon="location-outline" label="Based in" value={!editing && hasLocation ? profile.location : undefined} />
+                <Meta icon="business-outline" label="Company" value={!editing && hasCompany ? profile.company : undefined} />
+                <Meta icon="construct-outline" label="Jobs Completed" value={String(profile.jobsCompleted ?? 0)} />
+                <Meta icon="person-outline" label="Role" value="Client" />
+              </View>
+
+              {editing && (
+                <>
+                  <TextInput value={location} onChangeText={setLocation} style={styles.input} placeholder="Location" />
+                  <TextInput value={company} onChangeText={setCompany} style={styles.input} placeholder="Company" />
+                </>
+              )}
+            </View>
+
+            {/* About */}
+            {(editing || hasBio) && (
+              <View style={styles.card}>
+                <Text style={styles.sectionTitle}>About</Text>
+                {editing ? (
+                  <TextInput
+                    multiline
+                    value={bio}
+                    onChangeText={setBio}
+                    style={[styles.input, { minHeight: 100, textAlignVertical: "top" }]}
+                    placeholder="Tell people about yourself"
+                  />
+                ) : (
+                  <Text style={styles.bodyText}>{profile.bio}</Text>
+                )}
+              </View>
+            )}
+
+            {/* Qualifications */}
+            {(editing || profile.qualifications.length > 0) && (
+              <View style={styles.card}>
+                <View style={styles.rowBetween}>
+                  <Text style={styles.sectionTitle}>Qualifications</Text>
+                  {editing && (
+                    <Pressable onPress={addQual} style={[styles.btnSm, styles.btnGhost]}>
+                      <Ionicons name="add" size={18} />
+                      <Text style={styles.btnGhostText}>Add</Text>
+                    </Pressable>
+                  )}
+                </View>
+
+                {profile.qualifications.map((q) => (
+                  <View key={q.id} style={styles.qualRow}>
+                    <Pressable
+                      onPress={() => editing && pickImageForQual(q.id)}
+                      disabled={!editing}
+                      style={styles.qualImgWrap}
+                    >
+                      {q.imageUri ? (
+                        <Image source={{ uri: q.imageUri }} style={styles.qualImg} />
+                      ) : (
+                        <View style={[styles.qualImg, styles.qualPlaceholder]}>
+                          <Ionicons name="add" size={22} color="#6B7280" />
+                        </View>
+                      )}
+                    </Pressable>
+
+                    <View style={{ flex: 1 }}>
+                      {editing ? (
+                        <TextInput
+                          value={q.title}
+                          onChangeText={(t) =>
+                            updateQualification(userId, q.id, { title: t }, token ?? undefined)
+                          }
+                          style={styles.input}
+                          placeholder="Title"
+                        />
+                      ) : (
+                        <Text style={styles.qualTitle}>{q.title}</Text>
+                      )}
+                      <Text
+                        style={[
+                          styles.badge,
+                          q.status === "verified" ? styles.badgeVerified : styles.badgePending,
+                        ]}
+                      >
+                        {q.status === "verified" ? "Verified" : "Pending verification"}
+                      </Text>
+                    </View>
+
+                    {editing ? (
+                      <Pressable
+                        onPress={() => removeQualification(userId, q.id, token ?? undefined)}
+                        style={[styles.btnIcon, { borderColor: "#ef4444" }]}
+                        hitSlop={6}
+                      >
+                        <Ionicons name="trash" size={18} color="#ef4444" />
+                      </Pressable>
+                    ) : null}
+                  </View>
+                ))}
+              </View>
+            )}
+
+            {/* Skills */}
+            {(editing || profile.skills.length > 0) && (
+              <ChipsSection
+                title="Skills"
+                items={profile.skills}
+                editing={editing}
+                newValue={newSkill}
+                onChangeNew={setNewSkill}
+                onAdd={() => {
+                  if (!newSkill.trim()) return;
+                  addSkill(userId, newSkill.trim(), token ?? undefined);
+                  setNewSkill("");
+                }}
+                onRemove={(s) => removeSkill(userId, s, token ?? undefined)}
+              />
+            )}
+
+            {/* Interests */}
+            {(editing || profile.interests.length > 0) && (
+              <ChipsSection
+                title="Interests"
+                items={profile.interests}
+                editing={editing}
+                newValue={newInterest}
+                onChangeNew={setNewInterest}
+                onAdd={() => {
+                  if (!newInterest.trim()) return;
+                  addInterest(userId, newInterest.trim(), token ?? undefined);
+                  setNewInterest("");
+                }}
+                onRemove={(s) => removeInterest(userId, s, token ?? undefined)}
+              />
+            )}
+
+            {/* Save button */}
+            {editing && (
+              <View
+                style={{
+                  paddingHorizontal: 12,
+                  paddingTop: 8,
+                  paddingBottom: Math.max(insets.bottom, 8),
+                }}
+              >
+                <Pressable onPress={save} style={[styles.btn, styles.btnPrimary]}>
+                  <Text style={styles.btnPrimaryText}>Save changes</Text>
+                </Pressable>
+              </View>
+            )}
+          </ScrollView>
+        </View>
+      </KeyboardAvoidingView>
+    </>
+  );
+}
+
+function Meta({ icon, label, value }: { icon: any; label: string; value?: string }) {
+  if (!value) return null;
+  return (
+    <View style={styles.metaItem}>
+      <Ionicons name={icon} size={16} color="#6B7280" />
+      <Text style={styles.metaLabel}>{label}</Text>
+      <Text style={styles.metaValue}>{value}</Text>
+    </View>
+  );
+}
+
+function ChipsSection({
+  title,
+  items,
+  editing,
+  newValue,
+  onChangeNew,
+  onAdd,
+  onRemove,
+}: {
+  title: string;
+  items: string[];
+  editing: boolean;
+  newValue: string;
+  onChangeNew: (s: string) => void;
+  onAdd: () => void;
+  onRemove: (s: string) => void;
+}) {
+  return (
+    <View style={styles.card}>
+      <Text style={styles.sectionTitle}>{title}</Text>
+      <View style={{ flexDirection: "row", flexWrap: "wrap", gap: 8, marginTop: 8 }}>
+        {items.map((s) => (
+          <View key={s} style={styles.chip}>
+            <Text style={styles.chipText}>{s}</Text>
+            {editing && (
+              <Pressable onPress={() => onRemove(s)} hitSlop={6}>
+                <Ionicons name="close" size={14} color="#6B7280" />
+              </Pressable>
+            )}
+          </View>
+        ))}
+      </View>
+      {editing && (
+        <View style={{ flexDirection: "row", gap: 8, marginTop: 12 }}>
+          <TextInput
+            value={newValue}
+            onChangeText={onChangeNew}
+            placeholder={`Add ${title.slice(0, -1).toLowerCase()}`}
+            style={[styles.input, { flex: 1 }]}
+          />
+          <Pressable onPress={onAdd} style={[styles.btn, styles.btnGhost]}>
+            <Ionicons name="add" size={18} />
+            <Text style={styles.btnGhostText}>Add</Text>
+          </Pressable>
+        </View>
+      )}
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  topBar: {
+    paddingHorizontal: 12,
+    paddingBottom: 6,
+    borderBottomWidth: StyleSheet.hairlineWidth,
+    borderBottomColor: "#eee",
+    backgroundColor: "#fff",
+    flexDirection: "row",
+    alignItems: "center",
+    justifyContent: "space-between",
+  },
+  topTitle: { fontWeight: "800", fontSize: 18, color: "#1F2937" },
+
+  banner: { width: "100%", height: 140, backgroundColor: "#ddd" },
+  avatarWrap: { marginTop: -34, paddingHorizontal: 12, marginBottom: 6 },
+  avatar: { width: 68, height: 68, borderRadius: 34, borderWidth: 3, borderColor: "#fff" },
+
+  card: {
+    backgroundColor: "#fff",
+    borderRadius: 16,
+    marginHorizontal: 12,
+    marginTop: 10,
+    padding: 12,
+    borderWidth: StyleSheet.hairlineWidth,
+    borderColor: "#ececec",
+  },
+
+  name: { fontSize: 20, fontWeight: "800", color: "#111" },
+  headline: { color: "#374151", fontWeight: "600" },
+  rowCenter: { flexDirection: "row", alignItems: "center", gap: 8, marginTop: 2 },
+  dotOnline: { width: 10, height: 10, borderRadius: 5, backgroundColor: "#22c55e" },
+
+  metaGrid: { marginTop: 10, gap: 8 },
+  metaItem: { flexDirection: "row", alignItems: "center", gap: 6 },
+  metaLabel: { color: "#6B7280" },
+  metaValue: { color: "#111", fontWeight: "600" },
+
+  sectionTitle: { fontWeight: "800", fontSize: 16, color: "#1F2937" },
+  bodyText: { color: "#374151", lineHeight: 20 },
+
+  qualRow: { flexDirection: "row", alignItems: "center", gap: 10, marginTop: 10 },
+  qualImgWrap: { borderRadius: 8, overflow: "hidden" },
+  qualImg: { width: 110, height: 70, borderRadius: 8, backgroundColor: "#eee" },
+  qualPlaceholder: { alignItems: "center", justifyContent: "center" },
+  qualTitle: { fontWeight: "700", color: "#111", marginBottom: 4 },
+
+  chip: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: 6,
+    paddingVertical: 6,
+    paddingHorizontal: 10,
+    borderRadius: 999,
+    backgroundColor: "#F3F4F6",
+  },
+  chipText: { color: "#111", fontWeight: "600" },
+
+  input: {
+    borderWidth: StyleSheet.hairlineWidth,
+    borderColor: "#e5e7eb",
+    borderRadius: 10,
+    paddingHorizontal: 10,
+    paddingVertical: 10,
+    fontSize: 16,
+    backgroundColor: "#fff",
+  },
+  rowBetween: { flexDirection: "row", alignItems: "center", justifyContent: "space-between" },
+
+  btn: {
+    borderRadius: 12,
+    paddingVertical: 12,
+    paddingHorizontal: 14,
+    alignItems: "center",
+    justifyContent: "center",
+    flexDirection: "row",
+    gap: 6,
+  },
+  btnPrimary: { backgroundColor: Colors.primary },
+  btnPrimaryText: { color: "#fff", fontWeight: "800" },
+  btnGhost: { backgroundColor: "#fff", borderWidth: StyleSheet.hairlineWidth, borderColor: "#e5e7eb" },
+  btnGhostText: { fontWeight: "700", color: "#111" },
+  btnSm: { paddingVertical: 8, paddingHorizontal: 12, borderRadius: 10 },
+  btnIcon: { padding: 8, borderRadius: 10, borderWidth: StyleSheet.hairlineWidth, borderColor: "#e5e7eb" },
+
+  badge: {
+    alignSelf: "flex-start",
+    paddingHorizontal: 10,
+    paddingVertical: 5,
+    borderRadius: 999,
+    fontSize: 12,
+    overflow: "hidden",
+  },
+  badgeVerified: { backgroundColor: "#E9F9EE", color: "#1E7F3E" },
+  badgePending: { backgroundColor: "#FFF4CC", color: "#8A6A00" },
+});
+

--- a/mobile/src/components/TopBar.tsx
+++ b/mobile/src/components/TopBar.tsx
@@ -54,9 +54,11 @@ export default function TopBar({ overlay }: Props) {
       </Pressable>
 
       <View style={styles.actions}>
-        <Pressable onPress={onSaved} style={styles.iconBtn} accessibilityLabel="Saved">
-          <Ionicons name="heart-outline" size={22} />
-        </Pressable>
+        {group !== "(client)" && (
+          <Pressable onPress={onSaved} style={styles.iconBtn} accessibilityLabel="Saved">
+            <Ionicons name="heart-outline" size={22} />
+          </Pressable>
+        )}
 
         <Pressable onPress={goProfile} style={styles.avatarBtn} accessibilityLabel="Open profile">
           {avatarUri ? (


### PR DESCRIPTION
## Summary
- add detailed profile screen for clients, matching manager/labourer UI
- remove switch-to-contractor block and allow clients to edit avatar/banner
- wire up client tabs with hidden profile details route
- match client chats to other roles with AI removed and cross-role notifications
- hide saved heart button for clients

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68bb4eef2ef083209131ae283b71cef3