### PR TITLE
Enable native slide transition for labourer chats

### DIFF
--- a/mobile/app/(labourer)/chats/[id].tsx
+++ b/mobile/app/(labourer)/chats/[id].tsx
@@ -18,7 +18,7 @@ import {
   BackHandler,
   Image,
 } from "react-native";
-import { Stack, router, useLocalSearchParams } from "expo-router";
+import { router, useLocalSearchParams } from "expo-router";
 import { useFocusEffect } from "@react-navigation/native";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
 import { Colors } from "@src/theme/tokens";
@@ -425,7 +425,6 @@ export default function LabourerChatDetail() {
 
   return (
     <>
-      <Stack.Screen options={{ headerShown: false }} />
       <KeyboardAvoidingView
         style={styles.flex}
         behavior={Platform.OS === "ios" ? "padding" : "height"}

--- a/mobile/app/(labourer)/chats/_layout.tsx
+++ b/mobile/app/(labourer)/chats/_layout.tsx
@@ -1,0 +1,5 @@
+import { Stack } from "expo-router";
+
+export default function ChatsLayout() {
+  return <Stack screenOptions={{ animation: "slide_from_right", headerShown: false }} />;
+}

--- a/mobile/app/(labourer)/chats/index.tsx
+++ b/mobile/app/(labourer)/chats/index.tsx
@@ -79,7 +79,7 @@ export default function Chats() {
         >
           {item.id === 0 ? (
             <Image
-              source={require("../../assets/images/ConstructionAI.png")}
+              source={require("../../../assets/images/ConstructionAI.png")}
               style={styles.avatar}
             />
           ) : avatarUri ? (


### PR DESCRIPTION
## Summary
- move labourer chat list into its own stack
- apply native slide_from_right animation at the stack level
- clean up chat detail component to rely on stack layout

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68bb680198788320b73c73e676b2a7a9