### PR TITLE
feat: slide profile into chat

### DIFF
--- a/mobile/app/(client)/chats/[id].tsx
+++ b/mobile/app/(client)/chats/[id].tsx
@@ -267,6 +267,7 @@ export default function ClientChatDetail() {
         chatId: String(chatId),
         viewer: "client",
       },
+      animation: "slide_from_right",
     });
   }, [otherPartyId, chatId, chat]);
 

--- a/mobile/app/(labourer)/chats/[id].tsx
+++ b/mobile/app/(labourer)/chats/[id].tsx
@@ -296,6 +296,7 @@ export default function LabourerChatDetail() {
         chatId: String(chatId),
         viewer: "labourer",
       },
+      animation: "slide_from_right",
     });
   }, [otherPartyId, chatId]);
 

--- a/mobile/app/(manager)/chats/[id].tsx
+++ b/mobile/app/(manager)/chats/[id].tsx
@@ -315,6 +315,7 @@ export default function ManagerChatDetail() {
         chatId: String(chatId),
         viewer: "manager",
       },
+      animation: "slide_from_right",
     });
   }, [otherPartyId, chatId]);
 


### PR DESCRIPTION
## Summary
- slide labourer profiles from right when manager taps avatar in chat
- slide manager profiles from right when labourer taps avatar in chat
- slide participant profiles from right when client taps avatar in chat

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68bb7380089c8320b5597bf5f817af9f