### PR TITLE
feat: standardize back chevrons on profile and chat pages

### DIFF
--- a/mobile/app/(client)/chats/[id].tsx
+++ b/mobile/app/(client)/chats/[id].tsx
@@ -393,7 +393,7 @@ export default function ClientChatDetail() {
           {/* Header */}
           <View style={[styles.header, { paddingTop: insets.top + 6 }]}>
             <Pressable onPress={goBack} hitSlop={12}>
-              <Text style={styles.headerBack}>‹</Text>
+              <Ionicons name="chevron-back" size={24} color="#111" />
             </Pressable>
             {otherPartyId ? (
               <Pressable onPress={goToProfile} hitSlop={12}>
@@ -503,7 +503,6 @@ const styles = StyleSheet.create({
     alignItems: "center",
     gap: 8,
   },
-  headerBack: { fontSize: 26, lineHeight: 26, color: "#6B7280", paddingRight: 6 },
   headerTitle: { flex: 1, fontSize: 18, fontWeight: "600", color: "#111" },
 
   statusRow: {

--- a/mobile/app/(labourer)/(profile)/personal-info.tsx
+++ b/mobile/app/(labourer)/(profile)/personal-info.tsx
@@ -3,8 +3,7 @@ import { View, Text, TextInput, StyleSheet, Pressable, Alert, ScrollView } from 
 import { Colors } from "@src/theme/tokens";
 import { useAuth } from "@src/store/useAuth";
 import { useProfile, defaultProfile } from "@src/store/useProfile";
-import { router, Stack } from "expo-router";
-import { Ionicons } from "@expo/vector-icons";
+import { Stack } from "expo-router";
 
 
 export default function PersonalInfo() {
@@ -101,17 +100,6 @@ export default function PersonalInfo() {
           headerShown: true,
           headerTitle: "Personal information",
           headerShadowVisible: false,
-          headerLeft: () => (
-            <Pressable
-              onPress={() => router.back()}
-              accessibilityRole="button"
-              accessibilityLabel="Back to profile"
-              style={{ flexDirection: "row", alignItems: "center", paddingHorizontal: 8, paddingVertical: 4 }}
-            >
-              <Ionicons name="chevron-back" size={24} color="#111" />
-              <Text style={{ fontWeight: "600" }}>Back</Text>
-            </Pressable>
-          ),
         }}
       />
 

--- a/mobile/app/(labourer)/(profile)/saved.tsx
+++ b/mobile/app/(labourer)/(profile)/saved.tsx
@@ -82,7 +82,9 @@ export default function SavedJobs() {
       <Modal visible={open} animationType="slide" presentationStyle="pageSheet" onRequestClose={() => setOpen(false)}>
         <ScrollView contentContainerStyle={{ paddingBottom: 24 }}>
           <View style={{ paddingHorizontal:12, paddingTop:14, paddingBottom:8, flexDirection:"row", alignItems:"center", justifyContent:"space-between" }}>
-            <Pressable onPress={() => setOpen(false)} style={{ padding:6 }}><Ionicons name="chevron-back" size={24} /></Pressable>
+            <Pressable onPress={() => setOpen(false)} style={{ padding:6 }}>
+              <Ionicons name="chevron-back" size={24} color="#111" />
+            </Pressable>
             <Text style={{ fontWeight:"800", fontSize:18, color:"#1F2937" }}>Job details</Text>
             <View style={{ width:30 }} />
           </View>

--- a/mobile/app/(labourer)/(profile)/switch-to-contractor.tsx
+++ b/mobile/app/(labourer)/(profile)/switch-to-contractor.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import { View, Text, StyleSheet, ScrollView, Pressable, Alert } from "react-native";
 import { Colors } from "@src/theme/tokens";
-import { Stack, router } from "expo-router";
+import { Stack } from "expo-router";
 import { Ionicons } from "@expo/vector-icons";
 
 export default function SwitchToContractor() {
@@ -17,17 +17,6 @@ export default function SwitchToContractor() {
           headerShown: true,
           headerTitle: "Switch to contractor",
           headerShadowVisible: false,
-          headerLeft: () => (
-            <Pressable
-              onPress={() => router.back()}
-              accessibilityRole="button"
-              accessibilityLabel="Back to profile"
-              style={({ pressed }) => [{ opacity: pressed ? 0.6 : 1 }]}
-              hitSlop={{ top: 8, bottom: 8, left: 8, right: 8 }}
-            >
-              <Ionicons name="chevron-back" size={22} color="#111827" />
-            </Pressable>
-          ),
         }}
       />
 

--- a/mobile/app/(labourer)/chats/[id].tsx
+++ b/mobile/app/(labourer)/chats/[id].tsx
@@ -435,7 +435,7 @@ export default function LabourerChatDetail() {
           {/* Header */}
           <View style={[styles.header, { paddingTop: insets.top + 6 }]}>
             <Pressable onPress={goBack} hitSlop={12}>
-              <Text style={styles.headerBack}>‹</Text>
+              <Ionicons name="chevron-back" size={24} color="#111" />
             </Pressable>
             {otherPartyId ? (
               <Pressable onPress={goToProfile} hitSlop={12}>
@@ -546,7 +546,6 @@ const styles = StyleSheet.create({
     alignItems: "center",
     gap: 8,
   },
-  headerBack: { fontSize: 26, lineHeight: 26, color: "#6B7280", paddingRight: 6 },
   headerTitle: { flex: 1, fontSize: 18, fontWeight: "600", color: "#111" },
 
   statusRow: {

--- a/mobile/app/(manager)/(profile)/personal-info.tsx
+++ b/mobile/app/(manager)/(profile)/personal-info.tsx
@@ -3,8 +3,7 @@ import { View, Text, TextInput, StyleSheet, Pressable, Alert, ScrollView } from 
 import { Colors } from "@src/theme/tokens";
 import { useAuth } from "@src/store/useAuth";
 import { useProfile, defaultProfile } from "@src/store/useProfile";
-import { router, Stack } from "expo-router";
-import { Ionicons } from "@expo/vector-icons";
+import { Stack } from "expo-router";
 
 
 export default function PersonalInfo() {
@@ -100,17 +99,6 @@ export default function PersonalInfo() {
           headerShown: true,
           headerTitle: "Personal information",
           headerShadowVisible: false,
-          headerLeft: () => (
-            <Pressable
-              onPress={() => router.back()}
-              accessibilityRole="button"
-              accessibilityLabel="Back to profile"
-              style={{ flexDirection: "row", alignItems: "center", paddingHorizontal: 8, paddingVertical: 4 }}
-            >
-              <Ionicons name="chevron-back" size={24} color="#111" />
-              <Text style={{ fontWeight: "600" }}>Back</Text>
-            </Pressable>
-          ),
         }}
       />
 

--- a/mobile/app/(manager)/chats/[id].tsx
+++ b/mobile/app/(manager)/chats/[id].tsx
@@ -454,7 +454,7 @@ export default function ManagerChatDetail() {
           {/* Header */}
           <View style={[styles.header, { paddingTop: insets.top + 6 }]}>
             <Pressable onPress={goBack} hitSlop={12}>
-              <Text style={styles.headerBack}>‹</Text>
+              <Ionicons name="chevron-back" size={24} color="#111" />
             </Pressable>
             {otherPartyId ? (
               <Pressable onPress={goToProfile} hitSlop={12}>
@@ -584,7 +584,6 @@ const styles = StyleSheet.create({
     alignItems: "center",
     gap: 8,
   },
-  headerBack: { fontSize: 26, lineHeight: 26, color: "#6B7280", paddingRight: 6 },
   headerTitle: { flex: 1, fontSize: 18, fontWeight: "600", color: "#111" },
 
   statusRow: {

--- a/mobile/src/components/ProSubscription.tsx
+++ b/mobile/src/components/ProSubscription.tsx
@@ -9,7 +9,7 @@ import {
   Alert,
   AppState,
 } from "react-native";
-import { Stack, router, useFocusEffect } from "expo-router";
+import { Stack, useFocusEffect } from "expo-router";
 import { Ionicons } from "@expo/vector-icons";
 import { Colors } from "@src/theme/tokens";
 import { useAuth } from "@src/store/useAuth";
@@ -80,22 +80,6 @@ export default function ProSubscription() {
           headerShown: true,
           headerTitle: "BuildBoard Pro",
           headerShadowVisible: false,
-          headerLeft: () => (
-            <Pressable
-              onPress={router.back}
-              accessibilityRole="button"
-              style={({ pressed }) => ({
-                flexDirection: "row",
-                alignItems: "center",
-                gap: 4,
-                opacity: pressed ? 0.6 : 1,
-              })}
-              hitSlop={{ top: 8, bottom: 8, left: 8, right: 8 }}
-            >
-              <Ionicons name="chevron-back" size={22} color="#111827" />
-              <Text style={{ fontSize: 16 }}>Back</Text>
-            </Pressable>
-          ),
         }}
       />
 


### PR DESCRIPTION
## Summary
- replace text back buttons on personal info and subscription screens with default chevron
- unify back chevron icon size and color across profile pages and chat

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68bb8529e16c8320962c3275d8c40c35