### PR TITLE
fix profile navigation and ts errors

### DIFF
--- a/mobile/app/(client)/(profile)/_layout.tsx
+++ b/mobile/app/(client)/(profile)/_layout.tsx
@@ -7,7 +7,6 @@ export default function ProfileStack() {
     <Stack
       screenOptions={{
         animation: "slide_from_right",
-        headerBackTitleVisible: false,
         headerLeft: () => (
           <Pressable onPress={() => router.back()} hitSlop={12}>
             <Ionicons name="chevron-back" size={24} color="#111" />
@@ -15,7 +14,13 @@ export default function ProfileStack() {
         ),
       }}
     >
-      <Stack.Screen name="index" options={{ headerShown: false }} />
+      <Stack.Screen
+        name="index"
+        options={{
+          headerShown: false,
+          animation: "none",
+        }}
+      />
     </Stack>
   );
 }

--- a/mobile/app/(client)/(profile)/_layout.tsx
+++ b/mobile/app/(client)/(profile)/_layout.tsx
@@ -19,6 +19,7 @@ export default function ProfileStack() {
         options={{
           headerShown: false,
           animation: "none",
+          gestureEnabled: false,
         }}
       />
     </Stack>

--- a/mobile/app/(client)/projects/[id].tsx
+++ b/mobile/app/(client)/projects/[id].tsx
@@ -8,7 +8,9 @@ export default function ProjectDetails() {
   const [proj, setProj] = useState<any | null>(null);
 
   useEffect(() => {
-    listProjects().then(all => setProj(all.find(p => String(p.id) === String(id)) ?? null));
+    listProjects().then(all =>
+      setProj(all.find((p: any) => String(p.id) === String(id)) ?? null)
+    );
   }, [id]);
 
   if (!proj) {

--- a/mobile/app/(labourer)/(profile)/_layout.tsx
+++ b/mobile/app/(labourer)/(profile)/_layout.tsx
@@ -7,7 +7,6 @@ export default function LabourerProfileStack() {
     <Stack
       screenOptions={{
         animation: "slide_from_right",
-        headerBackTitleVisible: false,
         headerLeft: () => (
           <Pressable onPress={() => router.back()} hitSlop={12}>
             <Ionicons name="chevron-back" size={24} color="#111" />
@@ -15,7 +14,14 @@ export default function LabourerProfileStack() {
         ),
       }}
     >
-      <Stack.Screen name="index" options={{ headerShown: false }} />
+      <Stack.Screen
+        name="index"
+        options={{
+          headerShown: false,
+          // Show profile instantly without the default slide animation
+          animation: "none",
+        }}
+      />
     </Stack>
   );
 }

--- a/mobile/app/(labourer)/(profile)/_layout.tsx
+++ b/mobile/app/(labourer)/(profile)/_layout.tsx
@@ -27,6 +27,7 @@ export default function LabourerProfileStack() {
         name="saved"
         options={{
           headerShown: false,
+          animation: "none",
           gestureEnabled: false,
         }}
       />

--- a/mobile/app/(labourer)/(profile)/_layout.tsx
+++ b/mobile/app/(labourer)/(profile)/_layout.tsx
@@ -20,6 +20,14 @@ export default function LabourerProfileStack() {
           headerShown: false,
           // Show profile instantly without the default slide animation
           animation: "none",
+          gestureEnabled: false,
+        }}
+      />
+      <Stack.Screen
+        name="saved"
+        options={{
+          headerShown: false,
+          gestureEnabled: false,
         }}
       />
     </Stack>

--- a/mobile/app/(manager)/(profile)/_layout.tsx
+++ b/mobile/app/(manager)/(profile)/_layout.tsx
@@ -7,7 +7,6 @@ export default function ManagerProfileStack() {
     <Stack
       screenOptions={{
         animation: "slide_from_right",
-        headerBackTitleVisible: false,
         headerLeft: () => (
           <Pressable onPress={() => router.back()} hitSlop={12}>
             <Ionicons name="chevron-back" size={24} color="#111" />
@@ -15,7 +14,13 @@ export default function ManagerProfileStack() {
         ),
       }}
     >
-      <Stack.Screen name="index" options={{ headerShown: false }} />
+      <Stack.Screen
+        name="index"
+        options={{
+          headerShown: false,
+          animation: "none",
+        }}
+      />
     </Stack>
   );
 }

--- a/mobile/app/(manager)/(profile)/_layout.tsx
+++ b/mobile/app/(manager)/(profile)/_layout.tsx
@@ -19,6 +19,7 @@ export default function ManagerProfileStack() {
         options={{
           headerShown: false,
           animation: "none",
+          gestureEnabled: false,
         }}
       />
     </Stack>

--- a/mobile/src/components/TopBar.tsx
+++ b/mobile/src/components/TopBar.tsx
@@ -30,13 +30,17 @@ export default function TopBar({ overlay }: Props) {
 
   const avatarUri = profiles[userId]?.avatarUri;
 
-  const inProfile = segments.includes("(profile)");
+  // Only treat the user as "in profile" when the current route is the profile index.
+  // Other screens inside the `(profile)` group such as `saved` should still allow
+  // navigation back to the profile page via the avatar button.
+  const inProfile = segments[segments.length - 1] === "(profile)";
   const goProfile = () => router.push(`/${group}/(profile)` as const);
   const onSearch = () => Alert.alert("Search", "Search coming soon.");
 
   const onSaved = () => {
     if (group === "(labourer)") {
-      router.push("/(labourer)/saved");
+      // Saved jobs live inside the profile group for labourers
+      router.push("/(labourer)/(profile)/saved" as const);
     } else {
       Alert.alert("Saved", "Saved items coming soon.");
     }


### PR DESCRIPTION
## Summary
- stop profile stacks from sliding in and remove unsupported options
- fix TopBar navigation and saved route path
- add missing type annotation in client project details

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`
- `npx tsc -p tsconfig.json --noEmit`


------
https://chatgpt.com/codex/tasks/task_e_68bc1c1c9eb883209387792542124107