### PR TITLE
feat: revamp login security layout

### DIFF
--- a/mobile/app/(client)/(profile)/login-security.tsx
+++ b/mobile/app/(client)/(profile)/login-security.tsx
@@ -1,7 +1,7 @@
 import { View, Text, StyleSheet, Pressable, Alert } from "react-native";
 import { Colors } from "@src/theme/tokens";
 import { useAuth } from "@src/store/useAuth";
-import { router } from "expo-router";
+import { router, Stack } from "expo-router";
 
 export default function LoginSecurity() {
   const deleteAccount = useAuth((s) => s.deleteAccount);
@@ -21,25 +21,32 @@ export default function LoginSecurity() {
   };
 
   return (
-    <View style={styles.container}>
-      <Text style={styles.heading}>Login and security</Text>
-      <Text style={styles.sectionHeading}>Account</Text>
-      <View style={styles.line} />
-      <View style={styles.row}>
-        <Text style={styles.title}>Delete your account</Text>
-        <Pressable onPress={confirmDelete}>
-          <Text style={styles.deleteLink}>Delete account</Text>
-        </Pressable>
+    <>
+      <Stack.Screen
+        options={{
+          headerShown: true,
+          headerTitle: "Login and security",
+          headerShadowVisible: false,
+        }}
+      />
+      <View style={styles.container}>
+        <Text style={styles.sectionHeading}>Account</Text>
+        <View style={styles.line} />
+        <View style={styles.row}>
+          <Text style={styles.title}>Delete your account</Text>
+          <Pressable onPress={confirmDelete}>
+            <Text style={styles.deleteLink}>Delete account</Text>
+          </Pressable>
+        </View>
+        <Text style={styles.message}>This action cannot be undone</Text>
       </View>
-      <Text style={styles.message}>This action cannot be undone</Text>
-    </View>
+    </>
   );
 }
 
 const styles = StyleSheet.create({
   container: { flex: 1, backgroundColor: "#fff", padding: 24, gap: 12 },
-  heading: { fontSize: 20, fontWeight: "700" },
-  sectionHeading: { fontSize: 20, fontWeight: "700", marginTop: 12 },
+  sectionHeading: { fontSize: 20, fontWeight: "700" },
   line: { height: 1, backgroundColor: Colors.border },
   row: {
     flexDirection: "row",

--- a/mobile/app/(client)/(profile)/login-security.tsx
+++ b/mobile/app/(client)/(profile)/login-security.tsx
@@ -22,12 +22,16 @@ export default function LoginSecurity() {
 
   return (
     <View style={styles.container}>
-      <Text style={styles.heading}>Account</Text>
-      <Text style={styles.title}>Delete your account</Text>
+      <Text style={styles.heading}>Login and security</Text>
+      <Text style={styles.sectionHeading}>Account</Text>
+      <View style={styles.line} />
+      <View style={styles.row}>
+        <Text style={styles.title}>Delete your account</Text>
+        <Pressable onPress={confirmDelete}>
+          <Text style={styles.deleteLink}>Delete account</Text>
+        </Pressable>
+      </View>
       <Text style={styles.message}>This action cannot be undone</Text>
-      <Pressable style={styles.button} onPress={confirmDelete}>
-        <Text style={styles.buttonText}>Delete account</Text>
-      </Pressable>
     </View>
   );
 }
@@ -35,15 +39,16 @@ export default function LoginSecurity() {
 const styles = StyleSheet.create({
   container: { flex: 1, backgroundColor: "#fff", padding: 24, gap: 12 },
   heading: { fontSize: 20, fontWeight: "700" },
-  title: { fontSize: 16, fontWeight: "600", marginTop: 12 },
-  message: { color: Colors.muted },
-  button: {
-    marginTop: 20,
-    backgroundColor: "#DC2626",
-    paddingVertical: 12,
-    borderRadius: 8,
+  sectionHeading: { fontSize: 20, fontWeight: "700", marginTop: 12 },
+  line: { height: 1, backgroundColor: Colors.border },
+  row: {
+    flexDirection: "row",
+    justifyContent: "space-between",
     alignItems: "center",
+    marginTop: 12,
   },
-  buttonText: { color: "#fff", fontWeight: "700" },
+  title: { fontSize: 16, fontWeight: "600" },
+  deleteLink: { color: Colors.text, textDecorationLine: "underline" },
+  message: { color: Colors.muted },
 });
 

--- a/mobile/app/(labourer)/(profile)/login-security.tsx
+++ b/mobile/app/(labourer)/(profile)/login-security.tsx
@@ -1,7 +1,7 @@
 import { View, Text, StyleSheet, Pressable, Alert } from "react-native";
 import { Colors } from "@src/theme/tokens";
 import { useAuth } from "@src/store/useAuth";
-import { router } from "expo-router";
+import { router, Stack } from "expo-router";
 
 export default function LoginSecurity() {
   const deleteAccount = useAuth((s) => s.deleteAccount);
@@ -21,25 +21,32 @@ export default function LoginSecurity() {
   };
 
   return (
-    <View style={styles.container}>
-      <Text style={styles.heading}>Login and security</Text>
-      <Text style={styles.sectionHeading}>Account</Text>
-      <View style={styles.line} />
-      <View style={styles.row}>
-        <Text style={styles.title}>Delete your account</Text>
-        <Pressable onPress={confirmDelete}>
-          <Text style={styles.deleteLink}>Delete account</Text>
-        </Pressable>
+    <>
+      <Stack.Screen
+        options={{
+          headerShown: true,
+          headerTitle: "Login and security",
+          headerShadowVisible: false,
+        }}
+      />
+      <View style={styles.container}>
+        <Text style={styles.sectionHeading}>Account</Text>
+        <View style={styles.line} />
+        <View style={styles.row}>
+          <Text style={styles.title}>Delete your account</Text>
+          <Pressable onPress={confirmDelete}>
+            <Text style={styles.deleteLink}>Delete account</Text>
+          </Pressable>
+        </View>
+        <Text style={styles.message}>This action cannot be undone</Text>
       </View>
-      <Text style={styles.message}>This action cannot be undone</Text>
-    </View>
+    </>
   );
 }
 
 const styles = StyleSheet.create({
   container: { flex: 1, backgroundColor: "#fff", padding: 24, gap: 12 },
-  heading: { fontSize: 20, fontWeight: "700" },
-  sectionHeading: { fontSize: 20, fontWeight: "700", marginTop: 12 },
+  sectionHeading: { fontSize: 20, fontWeight: "700" },
   line: { height: 1, backgroundColor: Colors.border },
   row: {
     flexDirection: "row",

--- a/mobile/app/(labourer)/(profile)/login-security.tsx
+++ b/mobile/app/(labourer)/(profile)/login-security.tsx
@@ -22,12 +22,16 @@ export default function LoginSecurity() {
 
   return (
     <View style={styles.container}>
-      <Text style={styles.heading}>Account</Text>
-      <Text style={styles.title}>Delete your account</Text>
+      <Text style={styles.heading}>Login and security</Text>
+      <Text style={styles.sectionHeading}>Account</Text>
+      <View style={styles.line} />
+      <View style={styles.row}>
+        <Text style={styles.title}>Delete your account</Text>
+        <Pressable onPress={confirmDelete}>
+          <Text style={styles.deleteLink}>Delete account</Text>
+        </Pressable>
+      </View>
       <Text style={styles.message}>This action cannot be undone</Text>
-      <Pressable style={styles.button} onPress={confirmDelete}>
-        <Text style={styles.buttonText}>Delete account</Text>
-      </Pressable>
     </View>
   );
 }
@@ -35,15 +39,16 @@ export default function LoginSecurity() {
 const styles = StyleSheet.create({
   container: { flex: 1, backgroundColor: "#fff", padding: 24, gap: 12 },
   heading: { fontSize: 20, fontWeight: "700" },
-  title: { fontSize: 16, fontWeight: "600", marginTop: 12 },
-  message: { color: Colors.muted },
-  button: {
-    marginTop: 20,
-    backgroundColor: "#DC2626",
-    paddingVertical: 12,
-    borderRadius: 8,
+  sectionHeading: { fontSize: 20, fontWeight: "700", marginTop: 12 },
+  line: { height: 1, backgroundColor: Colors.border },
+  row: {
+    flexDirection: "row",
+    justifyContent: "space-between",
     alignItems: "center",
+    marginTop: 12,
   },
-  buttonText: { color: "#fff", fontWeight: "700" },
+  title: { fontSize: 16, fontWeight: "600" },
+  deleteLink: { color: Colors.text, textDecorationLine: "underline" },
+  message: { color: Colors.muted },
 });
 

--- a/mobile/app/(manager)/(profile)/login-security.tsx
+++ b/mobile/app/(manager)/(profile)/login-security.tsx
@@ -1,7 +1,7 @@
 import { View, Text, StyleSheet, Pressable, Alert } from "react-native";
 import { Colors } from "@src/theme/tokens";
 import { useAuth } from "@src/store/useAuth";
-import { router } from "expo-router";
+import { router, Stack } from "expo-router";
 
 export default function LoginSecurity() {
   const deleteAccount = useAuth((s) => s.deleteAccount);
@@ -21,25 +21,32 @@ export default function LoginSecurity() {
   };
 
   return (
-    <View style={styles.container}>
-      <Text style={styles.heading}>Login and security</Text>
-      <Text style={styles.sectionHeading}>Account</Text>
-      <View style={styles.line} />
-      <View style={styles.row}>
-        <Text style={styles.title}>Delete your account</Text>
-        <Pressable onPress={confirmDelete}>
-          <Text style={styles.deleteLink}>Delete account</Text>
-        </Pressable>
+    <>
+      <Stack.Screen
+        options={{
+          headerShown: true,
+          headerTitle: "Login and security",
+          headerShadowVisible: false,
+        }}
+      />
+      <View style={styles.container}>
+        <Text style={styles.sectionHeading}>Account</Text>
+        <View style={styles.line} />
+        <View style={styles.row}>
+          <Text style={styles.title}>Delete your account</Text>
+          <Pressable onPress={confirmDelete}>
+            <Text style={styles.deleteLink}>Delete account</Text>
+          </Pressable>
+        </View>
+        <Text style={styles.message}>This action cannot be undone</Text>
       </View>
-      <Text style={styles.message}>This action cannot be undone</Text>
-    </View>
+    </>
   );
 }
 
 const styles = StyleSheet.create({
   container: { flex: 1, backgroundColor: "#fff", padding: 24, gap: 12 },
-  heading: { fontSize: 20, fontWeight: "700" },
-  sectionHeading: { fontSize: 20, fontWeight: "700", marginTop: 12 },
+  sectionHeading: { fontSize: 20, fontWeight: "700" },
   line: { height: 1, backgroundColor: Colors.border },
   row: {
     flexDirection: "row",

--- a/mobile/app/(manager)/(profile)/login-security.tsx
+++ b/mobile/app/(manager)/(profile)/login-security.tsx
@@ -22,12 +22,16 @@ export default function LoginSecurity() {
 
   return (
     <View style={styles.container}>
-      <Text style={styles.heading}>Account</Text>
-      <Text style={styles.title}>Delete your account</Text>
+      <Text style={styles.heading}>Login and security</Text>
+      <Text style={styles.sectionHeading}>Account</Text>
+      <View style={styles.line} />
+      <View style={styles.row}>
+        <Text style={styles.title}>Delete your account</Text>
+        <Pressable onPress={confirmDelete}>
+          <Text style={styles.deleteLink}>Delete account</Text>
+        </Pressable>
+      </View>
       <Text style={styles.message}>This action cannot be undone</Text>
-      <Pressable style={styles.button} onPress={confirmDelete}>
-        <Text style={styles.buttonText}>Delete account</Text>
-      </Pressable>
     </View>
   );
 }
@@ -35,15 +39,16 @@ export default function LoginSecurity() {
 const styles = StyleSheet.create({
   container: { flex: 1, backgroundColor: "#fff", padding: 24, gap: 12 },
   heading: { fontSize: 20, fontWeight: "700" },
-  title: { fontSize: 16, fontWeight: "600", marginTop: 12 },
-  message: { color: Colors.muted },
-  button: {
-    marginTop: 20,
-    backgroundColor: "#DC2626",
-    paddingVertical: 12,
-    borderRadius: 8,
+  sectionHeading: { fontSize: 20, fontWeight: "700", marginTop: 12 },
+  line: { height: 1, backgroundColor: Colors.border },
+  row: {
+    flexDirection: "row",
+    justifyContent: "space-between",
     alignItems: "center",
+    marginTop: 12,
   },
-  buttonText: { color: "#fff", fontWeight: "700" },
+  title: { fontSize: 16, fontWeight: "600" },
+  deleteLink: { color: Colors.text, textDecorationLine: "underline" },
+  message: { color: Colors.muted },
 });
 


### PR DESCRIPTION
## Summary
- show "Login and security" heading
- add divider under "Account"
- replace delete account button with underlined text link

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68bc4073958c832099aab304fccbf06b