### PR TITLE
Add terms acceptance step and decouple auth API

### DIFF
--- a/mobile/app/(auth)/account-type.tsx
+++ b/mobile/app/(auth)/account-type.tsx
@@ -8,28 +8,17 @@ import { useAuth } from "@src/store/useAuth";
 type Choice = "labourer" | "manager" | "client";
 
 export default function AccountType() {
-  const { setRole, completeRegistration } = useAuth();
+  const { setRole } = useAuth();
   const [selected, setSelected] = useState<Choice | null>(null);
-  const [err, setErr] = useState<string | null>(null);
-  const [busy, setBusy] = useState(false);
 
   const choose = (c: Choice) => {
     setSelected(c);
     setRole(c);
   };
 
-  const submit = async () => {
+  const submit = () => {
     if (!selected) return;
-    setBusy(true);
-    setErr(null);
-    try {
-      await completeRegistration();
-      router.replace("/(auth)/success");
-    } catch (e: any) {
-      setErr(e.message ?? "Registration failed");
-    } finally {
-      setBusy(false);
-    }
+    router.push("/(auth)/terms");
   };
 
   const Card = ({
@@ -51,7 +40,7 @@ export default function AccountType() {
     );
   };
 
-  const canRegister = !!selected && !busy;
+  const canRegister = !!selected;
 
   return (
     <View style={styles.container}>
@@ -67,15 +56,13 @@ export default function AccountType() {
         <Card label="Customer"   icon="person-circle-outline" value="client" />
       </View>
 
-      {!!err && <Text style={{ color:"#b00020", marginTop: 8 }}>{err}</Text>}
-
       <Pressable
         disabled={!canRegister}
         onPress={submit}
         style={[styles.btn, canRegister ? styles.btnPrimary : styles.btnDisabled]}
       >
         <Text style={canRegister ? styles.btnPrimaryText : styles.btnDisabledText}>
-          {busy ? "Registering…" : "Register"}
+          Next
         </Text>
       </Pressable>
 

--- a/mobile/app/(auth)/terms.tsx
+++ b/mobile/app/(auth)/terms.tsx
@@ -1,0 +1,81 @@
+import { useState } from "react";
+import { ScrollView, View, Text, StyleSheet, Pressable } from "react-native";
+import { router } from "expo-router";
+import { Ionicons } from "@expo/vector-icons";
+import { Colors } from "@src/theme/tokens";
+import { useAuth } from "@src/store/useAuth";
+import { TERMS } from "@/constants/terms";
+
+export default function Terms() {
+  const { completeRegistration } = useAuth();
+  const [accepted, setAccepted] = useState(false);
+  const [busy, setBusy] = useState(false);
+  const [err, setErr] = useState<string | null>(null);
+
+  const submit = async () => {
+    if (!accepted) return;
+    setBusy(true);
+    setErr(null);
+    try {
+      await completeRegistration();
+      router.replace("/(auth)/success");
+    } catch (e: any) {
+      setErr(e.message ?? "Registration failed");
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  return (
+    <View style={styles.container}>
+      <Pressable onPress={() => router.back()} style={styles.back}>
+        <Ionicons name="chevron-back" size={26} />
+      </Pressable>
+
+      <ScrollView style={styles.scroll} contentContainerStyle={styles.scrollContent}>
+        <Text style={styles.title}>Terms & Conditions</Text>
+        <Text style={styles.text}>{TERMS}</Text>
+      </ScrollView>
+
+      <View style={styles.checkboxRow}>
+        <Pressable
+          onPress={() => setAccepted(a => !a)}
+          style={[styles.checkbox, accepted && styles.checkboxChecked]}
+        >
+          {accepted && <Ionicons name="checkmark" size={16} color="#fff" />}
+        </Pressable>
+        <Text style={styles.checkboxLabel}>I accept the Terms & Conditions</Text>
+      </View>
+
+      {!!err && <Text style={{ color:"#b00020", marginBottom:8 }}>{err}</Text>}
+
+      <Pressable
+        disabled={!accepted || busy}
+        onPress={submit}
+        style={[styles.btn, (!accepted || busy) ? styles.btnDisabled : styles.btnPrimary]}
+      >
+        <Text style={(!accepted || busy) ? styles.btnDisabledText : styles.btnPrimaryText}>
+          {busy ? "Registering…" : "Accept & Register"}
+        </Text>
+      </Pressable>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container:{ flex:1, backgroundColor: Colors.bg, padding:24 },
+  back:{ marginTop:8, width:36, height:36, alignItems:"center", justifyContent:"center" },
+  scroll:{ flex:1, marginTop:8, marginBottom:16 },
+  scrollContent:{ paddingBottom:24 },
+  title:{ fontSize:26, fontWeight:"800", color: Colors.text, marginBottom:12 },
+  text:{ color: Colors.text, lineHeight:20 },
+  checkboxRow:{ flexDirection:"row", alignItems:"center", marginBottom:12 },
+  checkbox:{ width:24, height:24, borderRadius:4, borderWidth:1, borderColor: Colors.border, alignItems:"center", justifyContent:"center", marginRight:8 },
+  checkboxChecked:{ backgroundColor: Colors.primary, borderColor: Colors.primary },
+  checkboxLabel:{ flex:1, color: Colors.text },
+  btn:{ borderRadius:12, paddingVertical:16, alignItems:"center" },
+  btnPrimary:{ backgroundColor: Colors.primary },
+  btnPrimaryText:{ color:"#fff", fontWeight:"700" },
+  btnDisabled:{ backgroundColor:"#E5E7EB" },
+  btnDisabledText:{ color:"#9CA3AF", fontWeight:"700" }
+});

--- a/mobile/constants/terms.ts
+++ b/mobile/constants/terms.ts
@@ -1,0 +1,59 @@
+export const TERMS = `Terms of Service (BuildBoard Ltd)
+Effective Date: [Insert Date]
+Company: BuildBoard Ltd (registered in England & Wales, Company No. _)
+
+1. Introduction
+These Terms of Service (“Terms”) govern your access to and use of the BuildBoard mobile application and related services (“BuildBoard”, “we”, “us”, “our”). By registering for or using BuildBoard, you (“User”, “you”) agree to be bound by these Terms.
+BuildBoard provides a platform that connects homeowners seeking construction work, managers of construction teams or companies, and labourers seeking employment. BuildBoard is a matching platform only and does not itself perform or guarantee construction work.
+
+2. Eligibility
+You must be at least 18 years old to use BuildBoard.
+By registering, you confirm you have legal capacity to enter into contracts.
+
+3. User Accounts & Verification
+Users must provide accurate personal and professional information when creating accounts.
+BuildBoard may verify identity and qualifications of managers and labourers but does not verify right-to-work status.
+You are responsible for maintaining confidentiality of login credentials.
+
+4. Roles & Use of the Platform
+Homeowners may post job advertisements for work required at their property.
+Managers may (i) apply for homeowner jobs, (ii) post their own jobs, and (iii) invite labourers to join teams.
+Labourers may apply for jobs listed by managers.
+Managers may access project management functions (task mapping, team organisation).
+
+5. Subscriptions & Payments
+BuildBoard offers a free and premium subscription.
+Premium subscribers receive boosted visibility, access to enhanced applicant pools, and additional project management features.
+Payments are processed via third-party providers (Stripe, PayPal). BuildBoard does not store payment card information.
+Subscription fees are non-refundable except as required by law.
+
+6. Matching & Transactions Between Users
+BuildBoard is not a party to agreements between homeowners, managers, and labourers.
+We do not guarantee:
+The availability, suitability, or quality of jobs or applicants.
+Completion of any work or payment between parties.
+Users are solely responsible for negotiating terms, payments, and work quality.
+
+7. Acceptable Use
+You agree not to:
+Post false, misleading, or fraudulent job ads or profiles.
+Harass, abuse, or discriminate against other users.
+Upload unlawful, offensive, or infringing content.
+Interfere with the operation or security of the platform.
+BuildBoard may suspend or terminate accounts that violate these Terms.
+
+8. Liability & Disclaimer
+BuildBoard provides the platform “as is” and without warranty of any kind.
+To the maximum extent permitted by law:
+We exclude liability for any indirect, incidental, or consequential damages.
+Our total liability to any user shall not exceed the amount paid by that user to BuildBoard in the 12 months preceding a claim.
+Nothing in these Terms limits liability for death, personal injury, or fraud caused by our negligence.
+
+9. Data & Privacy
+Use of BuildBoard is subject to our Privacy Policy, which explains how we collect, use, and protect your personal data in accordance with UK GDPR.
+
+10. Termination
+We may suspend or close your account at any time if you breach these Terms. You may stop using BuildBoard at any time.
+
+11. Governing Law
+These Terms are governed by the laws of England and Wales, and disputes will be subject to the exclusive jurisdiction of the courts of England and Wales.`;

--- a/mobile/src/lib/account.ts
+++ b/mobile/src/lib/account.ts
@@ -1,0 +1,24 @@
+const API_BASE = process.env.EXPO_PUBLIC_API_BASE_URL;
+
+const headers = (token?: string) => ({
+  "Content-Type": "application/json",
+  ...(token ? { Authorization: `Bearer ${token}` } : {})
+});
+
+export async function deleteAccount(token?: string) {
+  if (API_BASE && token) {
+    try {
+      const r = await fetch(`${API_BASE}/users/me`, {
+        method: "DELETE",
+        headers: headers(token),
+      });
+      if (!r.ok) {
+        throw new Error(`Failed to delete account (${r.status})`);
+      }
+    } catch (e) {
+      console.warn("Delete account request failed", e);
+    }
+  }
+  // In mock mode nothing to clean up
+  return Promise.resolve();
+}

--- a/mobile/src/lib/api.ts
+++ b/mobile/src/lib/api.ts
@@ -697,23 +697,8 @@ export async function createProject(p: { title: string; site: string; when: stri
   _projects.push(proj);
   return Promise.resolve(proj);
 }
-export async function listTeam() { return Promise.resolve([{ id: 1, name: "Sam Carter", role: "Site Supervisor", status: "online" }]); }
-
-// ---- Account ----
-export async function deleteAccount(token?: string) {
-  if (API_BASE && token) {
-    try {
-      const r = await fetch(`${API_BASE}/users/me`, {
-        method: "DELETE",
-        headers: headers(token),
-      });
-      if (!r.ok) {
-        throw new Error(`Failed to delete account (${r.status})`);
-      }
-    } catch (e) {
-      console.warn("Delete account request failed", e);
-    }
-  }
-  // In mock mode nothing to clean up
-  return Promise.resolve();
+export async function listTeam() {
+  return Promise.resolve([
+    { id: 1, name: "Sam Carter", role: "Site Supervisor", status: "online" }
+  ]);
 }

--- a/mobile/src/store/useAuth.ts
+++ b/mobile/src/store/useAuth.ts
@@ -1,7 +1,7 @@
 import { create } from "zustand";
 import { persist, createJSONStorage } from "zustand/middleware";
 import AsyncStorage from "@react-native-async-storage/async-storage";
-import { deleteAccount as apiDeleteAccount } from "@src/lib/api";
+import { deleteAccount as apiDeleteAccount } from "@src/lib/account";
 
 type Role = "client" | "manager" | "labourer";
 type PendingReg = { username: string; email: string; password: string } | null;


### PR DESCRIPTION
## Summary
- move `deleteAccount` into new stateless `account` helper to break circular import
- require users to accept Terms & Conditions via new screen before completing registration
- store Terms text in a dedicated constants file for reuse

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68bc8f989d148320873635a271b12a81