### PR TITLE
Rename navigation items and blank client map

### DIFF
--- a/mobile/app/(client)/_layout.tsx
+++ b/mobile/app/(client)/_layout.tsx
@@ -44,7 +44,7 @@ export default function ClientTabs() {
         options={{ title: "Chats", tabBarBadge: unread > 0 ? unread : undefined }}
       />
       <Tabs.Screen name="projects/index" options={{ title: "Projects" }} />
-      <Tabs.Screen name="map" options={{ title: "Map" }} />
+      <Tabs.Screen name="map" options={{ title: "Discover" }} />
     </Tabs>
   );
 }

--- a/mobile/app/(client)/map.tsx
+++ b/mobile/app/(client)/map.tsx
@@ -1,41 +1,14 @@
-import { useEffect, useRef, useState, useCallback } from "react";
 import { View, StyleSheet } from "react-native";
-import MapView, { Marker, PROVIDER_GOOGLE, Region } from "react-native-maps";
-import { listJobLocations } from "@src/lib/api";
 import TopBar from "@src/components/TopBar";
-import { useFocusEffect } from "@react-navigation/native";
 
-export default function ClientMap() {
-  const [markers, setMarkers] = useState<any[]>([]);
-  const mapRef = useRef<MapView>(null);
-
-  const load = async () => {
-    const m = await listJobLocations();
-    setMarkers(m);
-  };
-
-  useFocusEffect(useCallback(() => { load(); }, []));
-
-  useEffect(() => {
-    if (markers.length && mapRef.current) {
-      mapRef.current.fitToCoordinates(markers.map(m => m.coords), {
-        edgePadding: { top: 80, right: 40, bottom: 40, left: 40 },
-        animated: true
-      });
-    }
-  }, [markers]);
-
-  const initial: Region = { latitude: 51.5074, longitude: -0.1278, latitudeDelta: 0.4, longitudeDelta: 0.4 };
-
+export default function ClientDiscover() {
   return (
     <View style={styles.container}>
       <TopBar />
-      <MapView ref={mapRef} style={styles.map} provider={PROVIDER_GOOGLE} initialRegion={initial}>
-        {markers.map((m) => (
-          <Marker key={m.id} coordinate={m.coords} title={m.title} description={m.site} />
-        ))}
-      </MapView>
     </View>
   );
 }
-const styles = StyleSheet.create({ container:{ flex:1, backgroundColor:"#fff" }, map:{ flex:1 } });
+
+const styles = StyleSheet.create({
+  container: { flex: 1, backgroundColor: "#fff" },
+});

--- a/mobile/app/(labourer)/_layout.tsx
+++ b/mobile/app/(labourer)/_layout.tsx
@@ -40,7 +40,7 @@ export default function LabourerTabs() {
       />
       <Tabs.Screen name="jobs"  options={{ title: "Jobs" }} />
       <Tabs.Screen name="map"   options={{ title: "Map" }} />
-      <Tabs.Screen name="team"  options={{ title: "Team" }} />
+      <Tabs.Screen name="team"  options={{ title: "Tasks" }} />
     </Tabs>
   );
 }


### PR DESCRIPTION
## Summary
- Rename Labourer tab label from Team to Tasks
- Rename Client tab label from Map to Discover
- Remove map view on Client Map screen leaving only top bar

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68bcaf85fcec8320903402772657c63b