### PR TITLE
Fix client login redirect to My Jobs

### DIFF
--- a/mobile/app/(auth)/login.tsx
+++ b/mobile/app/(auth)/login.tsx
@@ -23,7 +23,7 @@ export default function Login() {
       // Redirect to a *real* screen (not the group root)
       if (role === "labourer") router.replace("/(labourer)/jobs");
       else if (role === "manager") router.replace("/(manager)/projects");
-      else router.replace("/(client)/projects/index");
+      else router.replace("/(client)/projects");
     } catch (e: any) {
       setErr(e.message ?? "Sign-in failed");
     }

--- a/mobile/app/(auth)/sign-in.tsx
+++ b/mobile/app/(auth)/sign-in.tsx
@@ -17,7 +17,7 @@ export default function SignIn() {
       const resolvedRole = await signIn(email.trim(), password);
       if (resolvedRole === "labourer") router.replace("/(labourer)/jobs");
       else if (resolvedRole === "manager") router.replace("/(manager)/projects");
-      else router.replace("/(client)/projects/index");
+      else router.replace("/(client)/projects");
     } catch (e: any) {
       setErr(e.message ?? "Sign-in failed");
     } finally {

--- a/mobile/app/(client)/index.tsx
+++ b/mobile/app/(client)/index.tsx
@@ -1,4 +1,4 @@
 import { Redirect } from "expo-router";
 export default function ClientIndex() {
-  return <Redirect href="/(client)/projects/index" />;
+  return <Redirect href="/(client)/projects" />;
 }

--- a/mobile/app/index.tsx
+++ b/mobile/app/index.tsx
@@ -24,5 +24,5 @@ export default function Index() {
   // Go to concrete screens that actually exist
   if (role === "labourer") return <Redirect href="/(labourer)/jobs" />;
   if (role === "manager")  return <Redirect href="/(manager)/projects" />;
-  return <Redirect href="/(client)/projects/index" />;
+  return <Redirect href="/(client)/projects" />;
 }

--- a/mobile/app/sign-in.tsx
+++ b/mobile/app/sign-in.tsx
@@ -18,7 +18,7 @@ export default function SignIn() {
       // send to role’s tab group
       if (resolvedRole === "labourer") router.replace("/(labourer)/jobs");
       else if (resolvedRole === "manager") router.replace("/(manager)/projects");
-      else router.replace("/(client)/projects/index");
+      else router.replace("/(client)/projects");
     } catch (e: any) {
       setErr(e.message ?? "Sign-in failed");
     } finally {


### PR DESCRIPTION
## Summary
- ensure client users land on My Jobs after login
- normalize client redirect paths

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68bcb7b88c8c8320bd9fae21a47ab3ae