### PR TITLE
Add consistent headers across role pages

### DIFF
--- a/mobile/app/(client)/map.tsx
+++ b/mobile/app/(client)/map.tsx
@@ -1,14 +1,19 @@
-import { View, StyleSheet } from "react-native";
+import { View, StyleSheet, Text } from "react-native";
 import TopBar from "@src/components/TopBar";
 
 export default function ClientDiscover() {
   return (
     <View style={styles.container}>
       <TopBar />
+      <View style={styles.headerRow}>
+        <Text style={styles.headerTitle}>Discover</Text>
+      </View>
     </View>
   );
 }
 
 const styles = StyleSheet.create({
   container: { flex: 1, backgroundColor: "#fff" },
+  headerRow:{ paddingHorizontal:12, paddingTop:6, paddingBottom:10, flexDirection:"row", alignItems:"center", justifyContent:"space-between" },
+  headerTitle:{ fontWeight:"800", fontSize:18, color:"#1F2937" },
 });

--- a/mobile/app/(client)/projects/index.tsx
+++ b/mobile/app/(client)/projects/index.tsx
@@ -1,4 +1,4 @@
-import { View, FlatList, StyleSheet } from "react-native";
+import { View, FlatList, StyleSheet, Text } from "react-native";
 import TopBar from "@src/components/TopBar";
 import { useEffect, useState } from "react";
 import { listProjects } from "@src/lib/api";
@@ -11,6 +11,9 @@ export default function ClientProjects() {
   return (
     <View style={styles.container}>
       <TopBar />
+      <View style={styles.headerRow}>
+        <Text style={styles.headerTitle}>My Jobs</Text>
+      </View>
       <FlatList
         contentContainerStyle={{ padding:12 }}
         data={items}
@@ -21,4 +24,8 @@ export default function ClientProjects() {
     </View>
   );
 }
-const styles = StyleSheet.create({ container:{ flex:1, backgroundColor:"#fff" } });
+const styles = StyleSheet.create({
+  container:{ flex:1, backgroundColor:"#fff" },
+  headerRow:{ paddingHorizontal:12, paddingTop:6, paddingBottom:10, flexDirection:"row", alignItems:"center", justifyContent:"space-between" },
+  headerTitle:{ fontWeight:"800", fontSize:18, color:"#1F2937" }
+});

--- a/mobile/app/(labourer)/jobs.tsx
+++ b/mobile/app/(labourer)/jobs.tsx
@@ -370,6 +370,9 @@ export default function Jobs() {
   return (
     <View style={{ flex: 1, backgroundColor: "#fff" }}>
       <TopBar />
+      <View style={styles.headerRow}>
+        <Text style={styles.headerTitle}>Jobs</Text>
+      </View>
       <ScrollView contentContainerStyle={{ paddingHorizontal: 12, paddingBottom: 24 }}>
         {renderSection("Featured Jobs", featuredJobs)}
         {renderSection("Recommended for You", recommendedJobs, true)}
@@ -532,6 +535,8 @@ const CARD_WIDTH = Dimensions.get("window").width - 24;
 
 const styles = StyleSheet.create({
   container: { flex: 1, backgroundColor: "#fff" },
+  headerRow:{ paddingHorizontal:12, paddingTop:6, paddingBottom:10, flexDirection:"row", alignItems:"center", justifyContent:"space-between" },
+  headerTitle:{ fontWeight:"800", fontSize:18, color:"#1F2937" },
   sectionTitle: { color: "#6B7280", fontWeight: "800", marginTop: 6, marginBottom: 8 },
   sectionDivider: { height: 1, backgroundColor: "#eee", marginVertical: 8 },
   empty: { color: "#6B7280", marginBottom: 8 },

--- a/mobile/app/(labourer)/team.tsx
+++ b/mobile/app/(labourer)/team.tsx
@@ -10,6 +10,9 @@ export default function Team() {
   return (
     <View style={styles.container}>
       <TopBar />
+      <View style={styles.headerRow}>
+        <Text style={styles.headerTitle}>Tasks</Text>
+      </View>
       <FlatList
         contentContainerStyle={{ padding:12 }}
         data={people}
@@ -38,6 +41,8 @@ export default function Team() {
 
 const styles = StyleSheet.create({
   container:{ flex:1, backgroundColor:"#fff" },
+  headerRow:{ paddingHorizontal:12, paddingTop:6, paddingBottom:10, flexDirection:"row", alignItems:"center", justifyContent:"space-between" },
+  headerTitle:{ fontWeight:"800", fontSize:18, color:"#1F2937" },
   row:{ flexDirection:"row", alignItems:"center", paddingVertical:10, paddingHorizontal:12 },
   avatar:{ width:40, height:40, borderRadius:20, backgroundColor:"#f1f5f9",
            alignItems:"center", justifyContent:"center", marginRight:12, borderWidth:1, borderColor:"#eee" },

--- a/mobile/app/(manager)/team.tsx
+++ b/mobile/app/(manager)/team.tsx
@@ -71,7 +71,7 @@ export default function ManagerTeam() {
     <View style={styles.container}>
       <TopBar />
       <View style={styles.headerRow}>
-         <Text style={styles.headerTitle}>Current Jobs</Text>
+         <Text style={styles.headerTitle}>Teams</Text>
       </View>
       <FlatList
         contentContainerStyle={jobs.length ? { padding:12 } : { padding:12, flexGrow:1, justifyContent:"center" }}


### PR DESCRIPTION
## Summary
- rename manager team page header to "Teams"
- add "Jobs" and "Tasks" headers to labourer pages with consistent styling
- add "My Jobs" and "Discover" headers to client pages

## Testing
- `npm test` (fails: Missing script)
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68bcbecc9cb88320a729fabbc4961e11