### PR TITLE
Add connections UI placeholder

### DIFF
--- a/mobile/app/(labourer)/(profile)/connections.tsx
+++ b/mobile/app/(labourer)/(profile)/connections.tsx
@@ -1,0 +1,60 @@
+import React from "react";
+import { View, Text, StyleSheet, ScrollView } from "react-native";
+import { Stack } from "expo-router";
+import { useSafeAreaInsets } from "react-native-safe-area-context";
+
+export default function Connections() {
+  const insets = useSafeAreaInsets();
+  const connections: { id: number; name: string }[] = [];
+
+  return (
+    <>
+      <Stack.Screen
+        options={{
+          headerShown: true,
+          headerTitle: "Connections",
+          headerShadowVisible: false,
+        }}
+      />
+      <ScrollView
+        contentContainerStyle={[
+          styles.container,
+          { paddingBottom: insets.bottom + 24 },
+        ]}
+      >
+        {connections.length === 0 ? (
+          <Text style={styles.emptyText}>You have no connections yet.</Text>
+        ) : (
+          connections.map((c) => (
+            <View key={c.id} style={styles.item}>
+              <Text style={styles.name}>{c.name}</Text>
+            </View>
+          ))
+        )}
+      </ScrollView>
+    </>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flexGrow: 1,
+    backgroundColor: "#fff",
+    padding: 16,
+  },
+  emptyText: {
+    textAlign: "center",
+    color: "#6B7280",
+    marginTop: 32,
+  },
+  item: {
+    paddingVertical: 12,
+    borderBottomWidth: StyleSheet.hairlineWidth,
+    borderBottomColor: "#E5E7EB",
+  },
+  name: {
+    fontSize: 16,
+    color: "#111827",
+  },
+});
+

--- a/mobile/app/(labourer)/(profile)/profileDetails.tsx
+++ b/mobile/app/(labourer)/(profile)/profileDetails.tsx
@@ -267,7 +267,7 @@ export default function LabourerProfileDetails() {
               </Pressable>
             </View>
             <Pressable
-              onPress={() => router.push("connections")}
+              onPress={() => router.push("/(labourer)/(profile)/connections")}
               style={({ pressed }) => [
                 styles.connectionsButton,
                 pressed && { opacity: 0.8 },
@@ -568,7 +568,7 @@ const styles = StyleSheet.create({
   connectionsButton: {
     position: "absolute",
     right: 12,
-    bottom: -20,
+    bottom: -28,
     flexDirection: "row",
     alignItems: "center",
     backgroundColor: "#E5E7EB",

--- a/mobile/app/(labourer)/(profile)/profileDetails.tsx
+++ b/mobile/app/(labourer)/(profile)/profileDetails.tsx
@@ -226,7 +226,8 @@ export default function LabourerProfileDetails() {
             }}
             keyboardShouldPersistTaps="handled"
           >
-            {/* Banner */}
+          {/* Banner */}
+          <View style={styles.bannerContainer}>
             <Pressable
               onPress={() => editing && pickImage("bannerUri")}
               disabled={!editing}
@@ -239,19 +240,6 @@ export default function LabourerProfileDetails() {
                 }}
                 style={styles.banner}
               />
-            </Pressable>
-
-            <Pressable
-              onPress={() => router.push("/(labourer)/(profile)/connections")}
-              style={({ pressed }) => [
-                styles.connectionsButton,
-                pressed && { opacity: 0.8 },
-              ]}
-              accessibilityRole="button"
-              accessibilityLabel="Connections"
-            >
-              <Ionicons name="people" size={16} color="#fff" />
-              <Text style={styles.connectionsText}>Connections</Text>
             </Pressable>
 
             {/* Avatar with silhouette fallback */}
@@ -278,9 +266,22 @@ export default function LabourerProfileDetails() {
                 )}
               </Pressable>
             </View>
+            <Pressable
+              onPress={() => router.push("connections")}
+              style={({ pressed }) => [
+                styles.connectionsButton,
+                pressed && { opacity: 0.8 },
+              ]}
+              accessibilityRole="button"
+              accessibilityLabel="Connections"
+            >
+              <Ionicons name="people" size={16} color="#111827" />
+              <Text style={styles.connectionsText}>Connections</Text>
+            </Pressable>
+          </View>
 
-            {/* Identity */}
-            <View style={styles.card}>
+          {/* Identity */}
+          <View style={styles.card}>
               {editing ? (
                 <>
                   <TextInput
@@ -562,21 +563,22 @@ const styles = StyleSheet.create({
   },
   topTitle: { fontWeight: "800", fontSize: 18, color: "#1F2937" },
 
+  bannerContainer: { position: "relative", marginBottom: 40 },
   banner: { width: "100%", height: 140, backgroundColor: "#ddd" },
   connectionsButton: {
+    position: "absolute",
+    right: 12,
+    bottom: -20,
     flexDirection: "row",
     alignItems: "center",
-    alignSelf: "flex-end",
-    backgroundColor: "#1E3A8A",
+    backgroundColor: "#E5E7EB",
     paddingHorizontal: 12,
     paddingVertical: 8,
     borderRadius: 8,
-    marginTop: 8,
-    marginRight: 12,
     gap: 4,
   },
-  connectionsText: { color: "#fff", fontWeight: "600" },
-  avatarWrap: { marginTop: -34, paddingHorizontal: 12, marginBottom: 6 },
+  connectionsText: { color: "#111827", fontWeight: "600" },
+  avatarWrap: { position: "absolute", left: 12, bottom: -34 },
   avatar: { width: 68, height: 68, borderRadius: 34, borderWidth: 3, borderColor: "#fff" },
 
   card: {

--- a/mobile/app/(labourer)/(profile)/profileDetails.tsx
+++ b/mobile/app/(labourer)/(profile)/profileDetails.tsx
@@ -568,7 +568,7 @@ const styles = StyleSheet.create({
   connectionsButton: {
     position: "absolute",
     right: 12,
-    bottom: -28,
+    bottom: -41,
     flexDirection: "row",
     alignItems: "center",
     backgroundColor: "#E5E7EB",

--- a/mobile/app/(labourer)/(profile)/profileDetails.tsx
+++ b/mobile/app/(labourer)/(profile)/profileDetails.tsx
@@ -241,6 +241,19 @@ export default function LabourerProfileDetails() {
               />
             </Pressable>
 
+            <Pressable
+              onPress={() => router.push("/(labourer)/(profile)/connections")}
+              style={({ pressed }) => [
+                styles.connectionsButton,
+                pressed && { opacity: 0.8 },
+              ]}
+              accessibilityRole="button"
+              accessibilityLabel="Connections"
+            >
+              <Ionicons name="people" size={16} color="#fff" />
+              <Text style={styles.connectionsText}>Connections</Text>
+            </Pressable>
+
             {/* Avatar with silhouette fallback */}
             <View style={styles.avatarWrap}>
               <Pressable
@@ -550,6 +563,19 @@ const styles = StyleSheet.create({
   topTitle: { fontWeight: "800", fontSize: 18, color: "#1F2937" },
 
   banner: { width: "100%", height: 140, backgroundColor: "#ddd" },
+  connectionsButton: {
+    flexDirection: "row",
+    alignItems: "center",
+    alignSelf: "flex-end",
+    backgroundColor: "#1E3A8A",
+    paddingHorizontal: 12,
+    paddingVertical: 8,
+    borderRadius: 8,
+    marginTop: 8,
+    marginRight: 12,
+    gap: 4,
+  },
+  connectionsText: { color: "#fff", fontWeight: "600" },
   avatarWrap: { marginTop: -34, paddingHorizontal: 12, marginBottom: 6 },
   avatar: { width: 68, height: 68, borderRadius: 34, borderWidth: 3, borderColor: "#fff" },
 

--- a/mobile/app/(manager)/(profile)/connections.tsx
+++ b/mobile/app/(manager)/(profile)/connections.tsx
@@ -1,0 +1,1 @@
+export { default } from "../../(labourer)/(profile)/connections";

--- a/mobile/app/(manager)/(profile)/profileDetails.tsx
+++ b/mobile/app/(manager)/(profile)/profileDetails.tsx
@@ -177,6 +177,19 @@ export default function ManagerProfileDetails() {
               />
             </Pressable>
 
+            <Pressable
+              onPress={() => router.push("/(manager)/(profile)/connections")}
+              style={({ pressed }) => [
+                styles.connectionsButton,
+                pressed && { opacity: 0.8 },
+              ]}
+              accessibilityRole="button"
+              accessibilityLabel="Connections"
+            >
+              <Ionicons name="people" size={16} color="#fff" />
+              <Text style={styles.connectionsText}>Connections</Text>
+            </Pressable>
+
             {/* Avatar with silhouette fallback */}
             <View style={styles.avatarWrap}>
               <Pressable onPress={() => editing && pickImage("avatarUri")} disabled={!editing}>
@@ -443,6 +456,19 @@ const styles = StyleSheet.create({
   topTitle: { fontWeight: "800", fontSize: 18, color: "#1F2937" },
 
   banner: { width: "100%", height: 140, backgroundColor: "#ddd" },
+  connectionsButton: {
+    flexDirection: "row",
+    alignItems: "center",
+    alignSelf: "flex-end",
+    backgroundColor: "#1E3A8A",
+    paddingHorizontal: 12,
+    paddingVertical: 8,
+    borderRadius: 8,
+    marginTop: 8,
+    marginRight: 12,
+    gap: 4,
+  },
+  connectionsText: { color: "#fff", fontWeight: "600" },
   avatarWrap: { marginTop: -34, paddingHorizontal: 12, marginBottom: 6 },
   avatar: { width: 68, height: 68, borderRadius: 34, borderWidth: 3, borderColor: "#fff" },
 

--- a/mobile/app/(manager)/(profile)/profileDetails.tsx
+++ b/mobile/app/(manager)/(profile)/profileDetails.tsx
@@ -196,7 +196,7 @@ export default function ManagerProfileDetails() {
                 </Pressable>
               </View>
               <Pressable
-                onPress={() => router.push("connections")}
+                onPress={() => router.push("/(manager)/(profile)/connections")}
                 style={({ pressed }) => [
                   styles.connectionsButton,
                   pressed && { opacity: 0.8 },
@@ -461,7 +461,7 @@ const styles = StyleSheet.create({
   connectionsButton: {
     position: "absolute",
     right: 12,
-    bottom: -20,
+    bottom: -28,
     flexDirection: "row",
     alignItems: "center",
     backgroundColor: "#E5E7EB",

--- a/mobile/app/(manager)/(profile)/profileDetails.tsx
+++ b/mobile/app/(manager)/(profile)/profileDetails.tsx
@@ -461,7 +461,7 @@ const styles = StyleSheet.create({
   connectionsButton: {
     position: "absolute",
     right: 12,
-    bottom: -28,
+    bottom: -41,
     flexDirection: "row",
     alignItems: "center",
     backgroundColor: "#E5E7EB",

--- a/mobile/app/(manager)/(profile)/profileDetails.tsx
+++ b/mobile/app/(manager)/(profile)/profileDetails.tsx
@@ -166,45 +166,46 @@ export default function ManagerProfileDetails() {
             keyboardShouldPersistTaps="handled"
           >
             {/* Banner */}
-            <Pressable onPress={() => editing && pickImage("bannerUri")} disabled={!editing}>
-              <Image
-                source={{
-                  uri:
-                    profile.bannerUri ??
-                    "https://images.unsplash.com/photo-1503264116251-35a269479413?q=80&w=1200&auto=format&fit=crop",
-                }}
-                style={styles.banner}
-              />
-            </Pressable>
+            <View style={styles.bannerContainer}>
+              <Pressable onPress={() => editing && pickImage("bannerUri")} disabled={!editing}>
+                <Image
+                  source={{
+                    uri:
+                      profile.bannerUri ??
+                      "https://images.unsplash.com/photo-1503264116251-35a269479413?q=80&w=1200&auto=format&fit=crop",
+                  }}
+                  style={styles.banner}
+                />
+              </Pressable>
 
-            <Pressable
-              onPress={() => router.push("/(manager)/(profile)/connections")}
-              style={({ pressed }) => [
-                styles.connectionsButton,
-                pressed && { opacity: 0.8 },
-              ]}
-              accessibilityRole="button"
-              accessibilityLabel="Connections"
-            >
-              <Ionicons name="people" size={16} color="#fff" />
-              <Text style={styles.connectionsText}>Connections</Text>
-            </Pressable>
-
-            {/* Avatar with silhouette fallback */}
-            <View style={styles.avatarWrap}>
-              <Pressable onPress={() => editing && pickImage("avatarUri")} disabled={!editing}>
-                {profile.avatarUri ? (
-                  <Image source={{ uri: profile.avatarUri }} style={styles.avatar} />
-                ) : (
-                  <View
-                    style={[
-                      styles.avatar,
-                      { alignItems: "center", justifyContent: "center", backgroundColor: "#E5E7EB" },
-                    ]}
-                  >
-                    <Ionicons name="person" size={28} color="#9CA3AF" />
-                  </View>
-                )}
+              {/* Avatar with silhouette fallback */}
+              <View style={styles.avatarWrap}>
+                <Pressable onPress={() => editing && pickImage("avatarUri")} disabled={!editing}>
+                  {profile.avatarUri ? (
+                    <Image source={{ uri: profile.avatarUri }} style={styles.avatar} />
+                  ) : (
+                    <View
+                      style={[
+                        styles.avatar,
+                        { alignItems: "center", justifyContent: "center", backgroundColor: "#E5E7EB" },
+                      ]}
+                    >
+                      <Ionicons name="person" size={28} color="#9CA3AF" />
+                    </View>
+                  )}
+                </Pressable>
+              </View>
+              <Pressable
+                onPress={() => router.push("connections")}
+                style={({ pressed }) => [
+                  styles.connectionsButton,
+                  pressed && { opacity: 0.8 },
+                ]}
+                accessibilityRole="button"
+                accessibilityLabel="Connections"
+              >
+                <Ionicons name="people" size={16} color="#111827" />
+                <Text style={styles.connectionsText}>Connections</Text>
               </Pressable>
             </View>
 
@@ -455,21 +456,22 @@ const styles = StyleSheet.create({
   },
   topTitle: { fontWeight: "800", fontSize: 18, color: "#1F2937" },
 
+  bannerContainer: { position: "relative", marginBottom: 40 },
   banner: { width: "100%", height: 140, backgroundColor: "#ddd" },
   connectionsButton: {
+    position: "absolute",
+    right: 12,
+    bottom: -20,
     flexDirection: "row",
     alignItems: "center",
-    alignSelf: "flex-end",
-    backgroundColor: "#1E3A8A",
+    backgroundColor: "#E5E7EB",
     paddingHorizontal: 12,
     paddingVertical: 8,
     borderRadius: 8,
-    marginTop: 8,
-    marginRight: 12,
     gap: 4,
   },
-  connectionsText: { color: "#fff", fontWeight: "600" },
-  avatarWrap: { marginTop: -34, paddingHorizontal: 12, marginBottom: 6 },
+  connectionsText: { color: "#111827", fontWeight: "600" },
+  avatarWrap: { position: "absolute", left: 12, bottom: -34 },
   avatar: { width: 68, height: 68, borderRadius: 34, borderWidth: 3, borderColor: "#fff" },
 
   card: {


### PR DESCRIPTION
## Summary
- add dark blue "Connections" button to labourer and manager profile details
- add placeholder connections page listing user connections

## Testing
- `npm test` *(fails: Missing script)*
- `npm test` in `mobile` *(fails: Missing script)*
- `npm run lint` in `mobile`

------
https://chatgpt.com/codex/tasks/task_e_68bcdbd7d7648320ab37cfbe7e59789e