### PR TITLE
Add connections search and backend

### DIFF
--- a/mobile/app/(labourer)/(profile)/connections.tsx
+++ b/mobile/app/(labourer)/(profile)/connections.tsx
@@ -1,0 +1,181 @@
+import React, { useEffect, useState } from "react";
+import {
+  View,
+  Text,
+  StyleSheet,
+  TextInput,
+  Pressable,
+  Image,
+  Alert,
+  FlatList,
+} from "react-native";
+import { Stack } from "expo-router";
+import { useSafeAreaInsets } from "react-native-safe-area-context";
+import { Ionicons } from "@expo/vector-icons";
+import {
+  listConnections,
+  sendConnectionRequest,
+  deleteConnection,
+  type ConnectionUser,
+} from "@src/lib/api";
+import { Swipeable } from "react-native-gesture-handler";
+
+export default function Connections() {
+  const insets = useSafeAreaInsets();
+  const [connections, setConnections] = useState<ConnectionUser[]>([]);
+  const [email, setEmail] = useState("");
+
+  useEffect(() => {
+    listConnections().then(setConnections);
+  }, []);
+
+  const handleInvite = async () => {
+    if (!email) return;
+    const res = await sendConnectionRequest(email.trim());
+    if (res.ok) {
+      Alert.alert("Request sent");
+      setEmail("");
+    } else if (res.error) {
+      Alert.alert(res.error);
+    }
+  };
+
+  const handleDelete = (id: number) => {
+    Alert.alert("Remove connection?", "This will delete for both users.", [
+      { text: "Cancel", style: "cancel" },
+      {
+        text: "Delete",
+        style: "destructive",
+        onPress: async () => {
+          setConnections((prev) => prev.filter((c) => c.id !== id));
+          await deleteConnection(id);
+        },
+      },
+    ]);
+  };
+
+  return (
+    <>
+      <Stack.Screen
+        options={{
+          headerShown: true,
+          headerTitle: "Connections",
+          headerShadowVisible: false,
+        }}
+      />
+      <FlatList
+        data={connections}
+        keyExtractor={(c) => String(c.id)}
+        contentContainerStyle={[
+          styles.container,
+          { paddingBottom: insets.bottom + 24 },
+        ]}
+        ListHeaderComponent={
+          <View style={styles.searchRow}>
+            <TextInput
+              value={email}
+              onChangeText={setEmail}
+              placeholder="Search by email"
+              style={styles.searchInput}
+              autoCapitalize="none"
+              keyboardType="email-address"
+            />
+            <Pressable style={styles.searchBtn} onPress={handleInvite}>
+              <Ionicons name="send" size={20} color="#fff" />
+            </Pressable>
+          </View>
+        }
+        renderItem={({ item }) => {
+          const thumb =
+            item.avatarUri || "https://via.placeholder.com/96x96?text=User";
+          return (
+            <Swipeable
+              renderRightActions={() => (
+                <Pressable
+                  style={styles.delete}
+                  onPress={() => handleDelete(item.id)}
+                >
+                  <Ionicons name="trash" size={20} color="#fff" />
+                  <Text style={styles.deleteText}>Delete</Text>
+                </Pressable>
+              )}
+            >
+              <View style={styles.row}>
+                <Image source={{ uri: thumb }} style={styles.avatar} />
+                <Text style={styles.name}>{item.username}</Text>
+              </View>
+            </Swipeable>
+          );
+        }}
+        ItemSeparatorComponent={() => <View style={{ height: 8 }} />}
+        ListEmptyComponent={<Text style={styles.emptyText}>You have no connections yet.</Text>}
+      />
+    </>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flexGrow: 1,
+    backgroundColor: "#fff",
+    padding: 16,
+  },
+  searchRow: {
+    flexDirection: "row",
+    alignItems: "center",
+    marginBottom: 16,
+  },
+  searchInput: {
+    flex: 1,
+    borderWidth: 1,
+    borderColor: "#E5E7EB",
+    borderRadius: 8,
+    paddingHorizontal: 12,
+    height: 40,
+  },
+  searchBtn: {
+    marginLeft: 8,
+    backgroundColor: "#9CA3AF",
+    padding: 10,
+    borderRadius: 8,
+  },
+  emptyText: {
+    textAlign: "center",
+    color: "#6B7280",
+    marginTop: 32,
+  },
+  row: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: 10,
+    padding: 12,
+    borderWidth: 1,
+    borderColor: "#eee",
+    borderRadius: 12,
+    backgroundColor: "#fff",
+  },
+  avatar: {
+    width: 44,
+    height: 44,
+    borderRadius: 22,
+    backgroundColor: "#E5E7EB",
+  },
+  name: {
+    fontSize: 16,
+    color: "#111827",
+  },
+  delete: {
+    backgroundColor: "#EF4444",
+    justifyContent: "center",
+    alignItems: "center",
+    width: 72,
+    borderRadius: 12,
+    marginLeft: 8,
+  },
+  deleteText: {
+    color: "#fff",
+    fontWeight: "600",
+    marginTop: 4,
+  },
+});
+

--- a/mobile/app/(labourer)/(profile)/profileDetails.tsx
+++ b/mobile/app/(labourer)/(profile)/profileDetails.tsx
@@ -226,7 +226,8 @@ export default function LabourerProfileDetails() {
             }}
             keyboardShouldPersistTaps="handled"
           >
-            {/* Banner */}
+          {/* Banner */}
+          <View style={styles.bannerContainer}>
             <Pressable
               onPress={() => editing && pickImage("bannerUri")}
               disabled={!editing}
@@ -265,9 +266,22 @@ export default function LabourerProfileDetails() {
                 )}
               </Pressable>
             </View>
+            <Pressable
+              onPress={() => router.push("/(labourer)/(profile)/connections")}
+              style={({ pressed }) => [
+                styles.connectionsButton,
+                pressed && { opacity: 0.8 },
+              ]}
+              accessibilityRole="button"
+              accessibilityLabel="Connections"
+            >
+              <Ionicons name="people" size={16} color="#111827" />
+              <Text style={styles.connectionsText}>Connections</Text>
+            </Pressable>
+          </View>
 
-            {/* Identity */}
-            <View style={styles.card}>
+          {/* Identity */}
+          <View style={styles.card}>
               {editing ? (
                 <>
                   <TextInput
@@ -549,8 +563,22 @@ const styles = StyleSheet.create({
   },
   topTitle: { fontWeight: "800", fontSize: 18, color: "#1F2937" },
 
+  bannerContainer: { position: "relative", marginBottom: 40 },
   banner: { width: "100%", height: 140, backgroundColor: "#ddd" },
-  avatarWrap: { marginTop: -34, paddingHorizontal: 12, marginBottom: 6 },
+  connectionsButton: {
+    position: "absolute",
+    right: 12,
+    bottom: -41,
+    flexDirection: "row",
+    alignItems: "center",
+    backgroundColor: "#E5E7EB",
+    paddingHorizontal: 12,
+    paddingVertical: 8,
+    borderRadius: 8,
+    gap: 4,
+  },
+  connectionsText: { color: "#111827", fontWeight: "600" },
+  avatarWrap: { position: "absolute", left: 12, bottom: -34 },
   avatar: { width: 68, height: 68, borderRadius: 34, borderWidth: 3, borderColor: "#fff" },
 
   card: {

--- a/mobile/app/(labourer)/_layout.tsx
+++ b/mobile/app/(labourer)/_layout.tsx
@@ -3,10 +3,20 @@ import { useAuth } from "@src/store/useAuth";
 import { Ionicons } from "@expo/vector-icons";
 import { Colors } from "@src/theme/tokens";
 import { useNotifications } from "@src/store/useNotifications";
+import { useEffect, useState } from "react";
+import { listConnectionRequests } from "@src/lib/api";
 
 export default function LabourerTabs() {
   const { signedIn } = useAuth();
   const unread = useNotifications((s) => s.unread.labourer);
+  const [reqCount, setReqCount] = useState(0);
+  useEffect(() => {
+    const load = () =>
+      listConnectionRequests().then((r) => setReqCount(r.length));
+    load();
+    const t = setInterval(load, 10000);
+    return () => clearInterval(t);
+  }, []);
   if (!signedIn) return <Redirect href="/(auth)/welcome" />;
 
   return (
@@ -40,7 +50,13 @@ export default function LabourerTabs() {
       />
       <Tabs.Screen name="jobs"  options={{ title: "Jobs" }} />
       <Tabs.Screen name="map"   options={{ title: "Map" }} />
-      <Tabs.Screen name="team"  options={{ title: "Tasks" }} />
+      <Tabs.Screen
+        name="team"
+        options={{
+          title: "Tasks",
+          tabBarBadge: reqCount > 0 ? reqCount : undefined,
+        }}
+      />
     </Tabs>
   );
 }

--- a/mobile/app/(labourer)/team.tsx
+++ b/mobile/app/(labourer)/team.tsx
@@ -1,11 +1,25 @@
 import { useEffect, useState } from "react";
-import { View, FlatList, Text, StyleSheet } from "react-native";
-import { listTeam } from "@src/lib/api";
+import { View, FlatList, Text, StyleSheet, Pressable, Image } from "react-native";
+import {
+  listTeam,
+  listConnectionRequests,
+  respondConnectionRequest,
+  type ConnectionRequest,
+} from "@src/lib/api";
 import TopBar from "@src/components/TopBar";
 
 export default function Team() {
   const [people, setPeople] = useState<any[]>([]);
-  useEffect(() => { listTeam().then(setPeople); }, []);
+  const [requests, setRequests] = useState<ConnectionRequest[]>([]);
+  useEffect(() => {
+    listTeam().then(setPeople);
+    listConnectionRequests().then(setRequests);
+  }, []);
+
+  const handleRespond = async (id: number, accept: boolean) => {
+    await respondConnectionRequest(id, accept);
+    setRequests((r) => r.filter((req) => req.id !== id));
+  };
 
   return (
     <View style={styles.container}>
@@ -13,6 +27,34 @@ export default function Team() {
       <View style={styles.headerRow}>
         <Text style={styles.headerTitle}>Tasks</Text>
       </View>
+      {requests.length > 0 && (
+        <View style={styles.reqContainer}>
+          {requests.map((r) => {
+            const thumb =
+              r.user.avatarUri || "https://via.placeholder.com/96x96?text=User";
+            return (
+              <View key={r.id} style={styles.reqRow}>
+                <Image source={{ uri: thumb }} style={styles.reqAvatar} />
+                <Text style={styles.reqName}>{r.user.username}</Text>
+                <View style={styles.reqActions}>
+                  <Pressable
+                    style={[styles.reqBtn, styles.accept]}
+                    onPress={() => handleRespond(r.id, true)}
+                  >
+                    <Text style={styles.reqBtnText}>Accept</Text>
+                  </Pressable>
+                  <Pressable
+                    style={[styles.reqBtn, styles.decline]}
+                    onPress={() => handleRespond(r.id, false)}
+                  >
+                    <Text style={styles.reqBtnText}>Decline</Text>
+                  </Pressable>
+                </View>
+              </View>
+            );
+          })}
+        </View>
+      )}
       <FlatList
         contentContainerStyle={{ padding:12 }}
         data={people}
@@ -43,6 +85,22 @@ const styles = StyleSheet.create({
   container:{ flex:1, backgroundColor:"#fff" },
   headerRow:{ paddingHorizontal:12, paddingTop:6, paddingBottom:10, flexDirection:"row", alignItems:"center", justifyContent:"space-between" },
   headerTitle:{ fontWeight:"800", fontSize:18, color:"#1F2937" },
+  badge:{
+    backgroundColor:"#DC2626",
+    borderRadius:12,
+    paddingHorizontal:6,
+    paddingVertical:2,
+  },
+  badgeText:{ color:"#fff", fontSize:12, fontWeight:"700" },
+  reqContainer:{ paddingHorizontal:12, paddingBottom:12 },
+  reqRow:{ flexDirection:"row", alignItems:"center", marginBottom:8 },
+  reqAvatar:{ width:40, height:40, borderRadius:20, marginRight:12, backgroundColor:"#f1f5f9" },
+  reqName:{ flex:1, fontWeight:"600" },
+  reqActions:{ flexDirection:"row", gap:8 },
+  reqBtn:{ paddingHorizontal:8, paddingVertical:6, borderRadius:6 },
+  accept:{ backgroundColor:"#16a34a" },
+  decline:{ backgroundColor:"#dc2626" },
+  reqBtnText:{ color:"#fff", fontSize:12 },
   row:{ flexDirection:"row", alignItems:"center", paddingVertical:10, paddingHorizontal:12 },
   avatar:{ width:40, height:40, borderRadius:20, backgroundColor:"#f1f5f9",
            alignItems:"center", justifyContent:"center", marginRight:12, borderWidth:1, borderColor:"#eee" },

--- a/mobile/app/(manager)/(profile)/connections.tsx
+++ b/mobile/app/(manager)/(profile)/connections.tsx
@@ -1,0 +1,1 @@
+export { default } from "../../(labourer)/(profile)/connections";

--- a/mobile/app/(manager)/(profile)/profileDetails.tsx
+++ b/mobile/app/(manager)/(profile)/profileDetails.tsx
@@ -166,32 +166,46 @@ export default function ManagerProfileDetails() {
             keyboardShouldPersistTaps="handled"
           >
             {/* Banner */}
-            <Pressable onPress={() => editing && pickImage("bannerUri")} disabled={!editing}>
-              <Image
-                source={{
-                  uri:
-                    profile.bannerUri ??
-                    "https://images.unsplash.com/photo-1503264116251-35a269479413?q=80&w=1200&auto=format&fit=crop",
-                }}
-                style={styles.banner}
-              />
-            </Pressable>
+            <View style={styles.bannerContainer}>
+              <Pressable onPress={() => editing && pickImage("bannerUri")} disabled={!editing}>
+                <Image
+                  source={{
+                    uri:
+                      profile.bannerUri ??
+                      "https://images.unsplash.com/photo-1503264116251-35a269479413?q=80&w=1200&auto=format&fit=crop",
+                  }}
+                  style={styles.banner}
+                />
+              </Pressable>
 
-            {/* Avatar with silhouette fallback */}
-            <View style={styles.avatarWrap}>
-              <Pressable onPress={() => editing && pickImage("avatarUri")} disabled={!editing}>
-                {profile.avatarUri ? (
-                  <Image source={{ uri: profile.avatarUri }} style={styles.avatar} />
-                ) : (
-                  <View
-                    style={[
-                      styles.avatar,
-                      { alignItems: "center", justifyContent: "center", backgroundColor: "#E5E7EB" },
-                    ]}
-                  >
-                    <Ionicons name="person" size={28} color="#9CA3AF" />
-                  </View>
-                )}
+              {/* Avatar with silhouette fallback */}
+              <View style={styles.avatarWrap}>
+                <Pressable onPress={() => editing && pickImage("avatarUri")} disabled={!editing}>
+                  {profile.avatarUri ? (
+                    <Image source={{ uri: profile.avatarUri }} style={styles.avatar} />
+                  ) : (
+                    <View
+                      style={[
+                        styles.avatar,
+                        { alignItems: "center", justifyContent: "center", backgroundColor: "#E5E7EB" },
+                      ]}
+                    >
+                      <Ionicons name="person" size={28} color="#9CA3AF" />
+                    </View>
+                  )}
+                </Pressable>
+              </View>
+              <Pressable
+                onPress={() => router.push("/(manager)/(profile)/connections")}
+                style={({ pressed }) => [
+                  styles.connectionsButton,
+                  pressed && { opacity: 0.8 },
+                ]}
+                accessibilityRole="button"
+                accessibilityLabel="Connections"
+              >
+                <Ionicons name="people" size={16} color="#111827" />
+                <Text style={styles.connectionsText}>Connections</Text>
               </Pressable>
             </View>
 
@@ -442,8 +456,22 @@ const styles = StyleSheet.create({
   },
   topTitle: { fontWeight: "800", fontSize: 18, color: "#1F2937" },
 
+  bannerContainer: { position: "relative", marginBottom: 40 },
   banner: { width: "100%", height: 140, backgroundColor: "#ddd" },
-  avatarWrap: { marginTop: -34, paddingHorizontal: 12, marginBottom: 6 },
+  connectionsButton: {
+    position: "absolute",
+    right: 12,
+    bottom: -41,
+    flexDirection: "row",
+    alignItems: "center",
+    backgroundColor: "#E5E7EB",
+    paddingHorizontal: 12,
+    paddingVertical: 8,
+    borderRadius: 8,
+    gap: 4,
+  },
+  connectionsText: { color: "#111827", fontWeight: "600" },
+  avatarWrap: { position: "absolute", left: 12, bottom: -34 },
   avatar: { width: 68, height: 68, borderRadius: 34, borderWidth: 3, borderColor: "#fff" },
 
   card: {

--- a/mobile/app/(manager)/_layout.tsx
+++ b/mobile/app/(manager)/_layout.tsx
@@ -3,10 +3,20 @@ import { useAuth } from "@src/store/useAuth";
 import { Ionicons } from "@expo/vector-icons";
 import { Colors } from "@src/theme/tokens";
 import { useNotifications } from "@src/store/useNotifications";
+import { useEffect, useState } from "react";
+import { listConnectionRequests } from "@src/lib/api";
 
 export default function ManagerTabs() {
   const { signedIn } = useAuth();
   const unread = useNotifications((s) => s.unread.manager);
+  const [reqCount, setReqCount] = useState(0);
+  useEffect(() => {
+    const load = () =>
+      listConnectionRequests().then((r) => setReqCount(r.length));
+    load();
+    const t = setInterval(load, 10000);
+    return () => clearInterval(t);
+  }, []);
   if (!signedIn) return <Redirect href="/(auth)/welcome" />;
 
   return (
@@ -40,7 +50,13 @@ export default function ManagerTabs() {
       />
       <Tabs.Screen name="projects" options={{ title: "Jobs" }} />
       <Tabs.Screen name="map"   options={{ title: "Map" }} />
-      <Tabs.Screen name="team"  options={{ title: "Team" }} />
+      <Tabs.Screen
+        name="team"
+        options={{
+          title: "Team",
+          tabBarBadge: reqCount > 0 ? reqCount : undefined,
+        }}
+      />
     </Tabs>
   );
 }

--- a/mobile/app/(manager)/team.tsx
+++ b/mobile/app/(manager)/team.tsx
@@ -1,6 +1,13 @@
 import { useEffect, useState } from "react";
 import { View, FlatList, Text, StyleSheet, Pressable, Modal, Image } from "react-native";
-import { listManagerJobs, listJobWorkers, type Job } from "@src/lib/api";
+import {
+  listManagerJobs,
+  listJobWorkers,
+  listConnectionRequests,
+  respondConnectionRequest,
+  type Job,
+  type ConnectionRequest,
+} from "@src/lib/api";
 import TopBar from "@src/components/TopBar";
 import { Ionicons } from "@expo/vector-icons";
 import { Colors } from "@src/theme/tokens";
@@ -11,6 +18,7 @@ export default function ManagerTeam() {
   const { user } = useAuth();
   const ownerId = user?.id;
   const [jobs, setJobs] = useState<Job[]>([]);
+  const [requests, setRequests] = useState<ConnectionRequest[]>([]);
   const [detailOpen, setDetailOpen] = useState(false);
   const [activeJob, setActiveJob] = useState<Job | null>(null);
   const [activeTab, setActiveTab] = useState<"team" | "tasks">("team");
@@ -29,6 +37,10 @@ export default function ManagerTeam() {
       setJobs(current);
     });
   }, [ownerId]);
+
+  useEffect(() => {
+    listConnectionRequests().then(setRequests);
+  }, []);
 
   useEffect(() => {
     if (detailOpen && activeTab === "team" && activeJob?.id) {
@@ -73,6 +85,40 @@ export default function ManagerTeam() {
       <View style={styles.headerRow}>
          <Text style={styles.headerTitle}>Teams</Text>
       </View>
+      {requests.length > 0 && (
+        <View style={styles.reqContainer}>
+          {requests.map((r) => {
+            const thumb =
+              r.user.avatarUri || "https://via.placeholder.com/96x96?text=User";
+            return (
+              <View key={r.id} style={styles.reqRow}>
+                <Image source={{ uri: thumb }} style={styles.reqAvatar} />
+                <Text style={styles.reqName}>{r.user.username}</Text>
+                <View style={styles.reqActions}>
+                  <Pressable
+                    style={[styles.reqBtn, styles.accept]}
+                    onPress={async () => {
+                      await respondConnectionRequest(r.id, true);
+                      setRequests((p) => p.filter((q) => q.id !== r.id));
+                    }}
+                  >
+                    <Text style={styles.reqBtnText}>Accept</Text>
+                  </Pressable>
+                  <Pressable
+                    style={[styles.reqBtn, styles.decline]}
+                    onPress={async () => {
+                      await respondConnectionRequest(r.id, false);
+                      setRequests((p) => p.filter((q) => q.id !== r.id));
+                    }}
+                  >
+                    <Text style={styles.reqBtnText}>Decline</Text>
+                  </Pressable>
+                </View>
+              </View>
+            );
+          })}
+        </View>
+      )}
       <FlatList
         contentContainerStyle={jobs.length ? { padding:12 } : { padding:12, flexGrow:1, justifyContent:"center" }}
         data={jobs}
@@ -150,6 +196,22 @@ const styles = StyleSheet.create({
   container:{ flex:1, backgroundColor:"#fff" },
   headerRow:{ paddingHorizontal:12, paddingTop:6, paddingBottom:10, flexDirection:"row", alignItems:"center", justifyContent:"space-between" },
   headerTitle:{ fontWeight:"800", fontSize:18, color:"#1F2937" },
+  badge:{
+    backgroundColor:"#DC2626",
+    borderRadius:12,
+    paddingHorizontal:6,
+    paddingVertical:2,
+  },
+  badgeText:{ color:"#fff", fontSize:12, fontWeight:"700" },
+  reqContainer:{ paddingHorizontal:12, paddingBottom:12 },
+  reqRow:{ flexDirection:"row", alignItems:"center", marginBottom:8 },
+  reqAvatar:{ width:40, height:40, borderRadius:20, marginRight:12, backgroundColor:"#f1f5f9" },
+  reqName:{ flex:1, fontWeight:"600" },
+  reqActions:{ flexDirection:"row", gap:8 },
+  reqBtn:{ paddingHorizontal:8, paddingVertical:6, borderRadius:6 },
+  accept:{ backgroundColor:"#16a34a" },
+  decline:{ backgroundColor:"#dc2626" },
+  reqBtnText:{ color:"#fff", fontSize:12 },
   tile:{ flexDirection:"row", alignItems:"center", padding:12, borderWidth:1, borderColor: Colors.border, borderRadius:12, backgroundColor:"#fff" },
   tileImg:{ width:48, height:48, borderRadius:8, marginRight:12, backgroundColor:"#f1f5f9" },
   tileTitle:{ flex:1, fontWeight:"600", color:"#1F2937" },

--- a/mobile/src/lib/api.ts
+++ b/mobile/src/lib/api.ts
@@ -69,6 +69,19 @@ export type Application = {
   createdAt: string;
 };
 
+export type ConnectionUser = {
+  id: number;
+  username: string;
+  email: string;
+  role: string;
+  avatarUri?: string;
+};
+
+export type ConnectionRequest = {
+  id: number;
+  user: ConnectionUser;
+};
+
 // ---- Demo Data ----
 let _jobs: Job[] = [
   {
@@ -145,6 +158,9 @@ let _messages: Record<number, Message[]> = {
 let _aiMessages: Message[] = [];
 
 let _applications: Application[] = [];
+
+let _connections: ConnectionUser[] = [];
+let _connectionRequests: ConnectionRequest[] = [];
 
 // ---- Helpers ----
 const headers = (token?: string) => ({
@@ -654,6 +670,98 @@ export async function saveProfile(profile: Profile, token?: string): Promise<voi
         body: JSON.stringify(clean),
       });
     } catch {}
+  }
+}
+
+// ---- Connections ----
+export async function listConnections(): Promise<ConnectionUser[]> {
+  const token = useAuth.getState().token;
+  if (API_BASE && token) {
+    try {
+      const r = await fetch(`${API_BASE}/connections`, { headers: headers(token) });
+      if (r.ok) return await r.json();
+    } catch {}
+  }
+  return _connections.slice();
+}
+
+export async function listConnectionRequests(): Promise<ConnectionRequest[]> {
+  const token = useAuth.getState().token;
+  if (API_BASE && token) {
+    try {
+      const r = await fetch(`${API_BASE}/connections/requests`, {
+        headers: headers(token),
+      });
+      if (r.ok) return await r.json();
+    } catch {}
+  }
+  return _connectionRequests.slice();
+}
+
+export async function sendConnectionRequest(
+  email: string
+): Promise<{ ok: boolean; error?: string }> {
+  const token = useAuth.getState().token;
+  if (API_BASE && token) {
+    try {
+      const r = await fetch(`${API_BASE}/connections/request`, {
+        method: "POST",
+        headers: headers(token),
+        body: JSON.stringify({ email }),
+      });
+      if (r.ok) return { ok: true };
+      let msg = "Error sending request";
+      try {
+        const text = await r.text();
+        try {
+          const data = JSON.parse(text);
+          if (data?.error) msg = data.error;
+        } catch {
+          if (text) msg = text;
+        }
+      } catch {}
+      return { ok: false, error: msg };
+    } catch {
+      return { ok: false, error: "Network error" };
+    }
+  }
+  const fakeUser: ConnectionUser = {
+    id: nextId(_connections),
+    username: email,
+    email,
+    role: "manager",
+  };
+  _connectionRequests.push({ id: nextId(_connectionRequests), user: fakeUser });
+  return { ok: true };
+}
+
+export async function deleteConnection(id: number): Promise<void> {
+  const token = useAuth.getState().token;
+  if (API_BASE && token) {
+    await fetch(`${API_BASE}/connections/${id}`, {
+      method: "DELETE",
+      headers: headers(token),
+    }).catch(() => {});
+    return;
+  }
+  const idx = _connections.findIndex((c) => c.id === id);
+  if (idx >= 0) _connections.splice(idx, 1);
+}
+
+export async function respondConnectionRequest(id: number, accept: boolean): Promise<void> {
+  const token = useAuth.getState().token;
+  if (API_BASE && token) {
+    await fetch(`${API_BASE}/connections/requests/${id}/respond`, {
+      method: "POST",
+      headers: headers(token),
+      body: JSON.stringify({ accept }),
+    }).catch(() => {});
+    return;
+  }
+  const idx = _connectionRequests.findIndex((r) => r.id === id);
+  if (idx >= 0) {
+    const req = _connectionRequests.splice(idx, 1)[0];
+    if (accept) _connections.push(req.user);
   }
 }
 

--- a/server/index.js
+++ b/server/index.js
@@ -222,6 +222,21 @@ const db = require("./db");
     status TEXT NOT NULL DEFAULT 'pending'
   )`);
 
+  await db.query(`CREATE TABLE IF NOT EXISTS connection_requests(
+    id SERIAL PRIMARY KEY,
+    sender_id INTEGER NOT NULL REFERENCES users(id),
+    receiver_id INTEGER NOT NULL REFERENCES users(id),
+    status TEXT NOT NULL DEFAULT 'pending',
+    created_at TIMESTAMP NOT NULL DEFAULT NOW(),
+    UNIQUE (sender_id, receiver_id)
+  )`);
+
+  await db.query(`CREATE TABLE IF NOT EXISTS connections(
+    user_id INTEGER NOT NULL REFERENCES users(id),
+    connection_id INTEGER NOT NULL REFERENCES users(id),
+    PRIMARY KEY (user_id, connection_id)
+  )`);
+
   await db.query(
     "INSERT INTO users (id, email, username, password_hash, role) VALUES (0, 'system@buildboard.local', 'system', '', 'system') ON CONFLICT (id) DO NOTHING"
   );
@@ -1235,6 +1250,16 @@ app.patch("/applications/by-chat/:chatId", auth, async (req, res) => {
     await db
       .prepare("INSERT INTO project_workers (project_id, user_id) VALUES (?, ?) ON CONFLICT DO NOTHING")
       .run(existing.job_id, existing.worker_id);
+    await db
+      .prepare(
+        "INSERT INTO connections (user_id, connection_id) VALUES (?, ?), (?, ?) ON CONFLICT DO NOTHING"
+      )
+      .run(
+        existing.manager_id,
+        existing.worker_id,
+        existing.worker_id,
+        existing.manager_id
+      );
   }
   const body = `Manager ${status} the application`;
   const msgId = (
@@ -1251,6 +1276,124 @@ app.patch("/applications/by-chat/:chatId", auth, async (req, res) => {
   io.to(`chat:${chatId}`).emit("message:new", msg);
   const appRow = await db.prepare("SELECT * FROM applications WHERE chat_id = ?").get(chatId);
   res.json(appRow);
+});
+
+// --- connections ---
+app.get("/connections", auth, async (req, res) => {
+  const rows = await db
+    .prepare(
+      `SELECT u.id, u.username, u.email, u.role, p.data
+       FROM connections c
+       JOIN users u ON u.id = c.connection_id
+       LEFT JOIN profiles p ON p.user_id = u.id
+       WHERE c.user_id = ?`
+    )
+    .all(req.user.sub);
+  const list = rows.map((r) => {
+    let avatarUri;
+    try {
+      avatarUri = JSON.parse(r.data || "{}").avatarUri;
+    } catch {}
+    return { id: r.id, username: r.username, email: r.email, role: r.role, avatarUri };
+  });
+  res.json(list);
+});
+
+app.get("/connections/requests", auth, async (req, res) => {
+  const rows = await db
+    .prepare(
+      `SELECT r.id, u.id as sender_id, u.username, u.email, u.role, p.data
+       FROM connection_requests r
+       JOIN users u ON u.id = r.sender_id
+       LEFT JOIN profiles p ON p.user_id = u.id
+       WHERE r.receiver_id = ? AND r.status = 'pending'`
+    )
+    .all(req.user.sub);
+  const list = rows.map((r) => {
+    let avatarUri;
+    try {
+      avatarUri = JSON.parse(r.data || "{}").avatarUri;
+    } catch {}
+    return {
+      id: r.id,
+      user: { id: r.sender_id, username: r.username, email: r.email, role: r.role, avatarUri },
+    };
+  });
+  res.json(list);
+});
+
+app.post("/connections/request", auth, async (req, res) => {
+  const { email } = req.body || {};
+  if (!email) return res.status(400).json({ error: "Missing email" });
+  const receiver = await db
+    .prepare("SELECT id, role FROM users WHERE email = ?")
+    .get(email);
+  if (!receiver) return res.status(404).json({ error: "User not found" });
+  if (receiver.id === req.user.sub)
+    return res.status(400).json({ error: "Cannot connect to yourself" });
+  const sender = await db
+    .prepare("SELECT role FROM users WHERE id = ?")
+    .get(req.user.sub);
+  if (sender.role === receiver.role)
+    return res
+      .status(400)
+      .json({ error: "Connections only between labourers and managers" });
+  const existing = await db
+    .prepare("SELECT 1 FROM connections WHERE user_id = ? AND connection_id = ?")
+    .get(req.user.sub, receiver.id);
+  if (existing) return res.status(400).json({ error: "Already connected" });
+  const existingReq = await db
+    .prepare(
+      "SELECT status FROM connection_requests WHERE sender_id = ? AND receiver_id = ?"
+    )
+    .get(req.user.sub, receiver.id);
+  if (existingReq?.status === "pending")
+    return res.status(400).json({ error: "Request already sent" });
+  if (existingReq) {
+    await db
+      .prepare(
+        "UPDATE connection_requests SET status = 'pending', created_at = NOW() WHERE sender_id = ? AND receiver_id = ?"
+      )
+      .run(req.user.sub, receiver.id);
+  } else {
+    await db
+      .prepare("INSERT INTO connection_requests (sender_id, receiver_id) VALUES (?, ?)")
+      .run(req.user.sub, receiver.id);
+  }
+  res.json({ ok: true });
+});
+
+app.post("/connections/requests/:id/respond", auth, async (req, res) => {
+  const id = Number(req.params.id);
+  const { accept } = req.body || {};
+  const row = await db
+    .prepare("SELECT * FROM connection_requests WHERE id = ?")
+    .get(id);
+  if (!row || row.receiver_id !== req.user.sub)
+    return res.status(404).json({ error: "Request not found" });
+  if (row.status !== "pending")
+    return res.status(400).json({ error: "Already handled" });
+  await db
+    .prepare("UPDATE connection_requests SET status = ? WHERE id = ?")
+    .run(accept ? "accepted" : "declined", id);
+  if (accept) {
+    await db
+      .prepare(
+        "INSERT INTO connections (user_id, connection_id) VALUES (?, ?), (?, ?) ON CONFLICT DO NOTHING"
+      )
+      .run(row.sender_id, row.receiver_id, row.receiver_id, row.sender_id);
+  }
+  res.json({ ok: true });
+});
+
+app.delete("/connections/:id", auth, async (req, res) => {
+  const otherId = Number(req.params.id);
+  await db
+    .prepare(
+      "DELETE FROM connections WHERE (user_id = ? AND connection_id = ?) OR (user_id = ? AND connection_id = ?)"
+    )
+    .run(req.user.sub, otherId, otherId, req.user.sub);
+  res.json({ ok: true });
 });
 
 // --- health (for quick checks)


### PR DESCRIPTION
## Summary
- add search/invite bar to connections page and display avatars
- surface pending connection requests with accept/decline on Tasks/Teams
- implement backend tables and endpoints for connection requests and links
- handle unknown emails and allow swipe-to-delete connections
- move connection request badge to tab icon and tile connection rows
- define missing badge styles on team pages to clear type errors
- fix connection request API to reuse existing records and show detailed errors on failure

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm test` in `mobile` *(fails: Missing script: "test")*
- `npm run lint` in `mobile`
- `npm test` in `server` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68bcdbd7d7648320ab37cfbe7e59789e