### PR TITLE
Remove in-page badge for connection requests

### DIFF
--- a/mobile/app/(labourer)/team.tsx
+++ b/mobile/app/(labourer)/team.tsx
@@ -26,11 +26,6 @@ export default function Team() {
       <TopBar />
       <View style={styles.headerRow}>
         <Text style={styles.headerTitle}>Tasks</Text>
-        {requests.length > 0 && (
-          <View style={styles.badge}>
-            <Text style={styles.badgeText}>{requests.length}</Text>
-          </View>
-        )}
       </View>
       {requests.length > 0 && (
         <View style={styles.reqContainer}>
@@ -88,23 +83,8 @@ export default function Team() {
 
 const styles = StyleSheet.create({
   container:{ flex:1, backgroundColor:"#fff" },
-  headerRow:{ paddingHorizontal:12, paddingTop:6, paddingBottom:10, flexDirection:"row", alignItems:"center", justifyContent:"space-between" },
+  headerRow:{ paddingHorizontal:12, paddingTop:6, paddingBottom:10, flexDirection:"row", alignItems:"center" },
   headerTitle:{ fontWeight:"800", fontSize:18, color:"#1F2937" },
-    badge: {
-    minWidth: 22,
-    height: 22,
-    paddingHorizontal: 6,
-    borderRadius: 11,
-    backgroundColor: "#ef4444", // red
-    alignItems: "center",
-    justifyContent: "center",
-  },
-  badgeText: {
-    color: "#fff",
-    fontWeight: "700",
-    fontSize: 12,
-    lineHeight: 14,
-  },
   reqContainer:{ paddingHorizontal:12, paddingBottom:12 },
   reqRow:{ flexDirection:"row", alignItems:"center", marginBottom:8 },
   reqAvatar:{ width:40, height:40, borderRadius:20, marginRight:12, backgroundColor:"#f1f5f9" },

--- a/mobile/app/(manager)/team.tsx
+++ b/mobile/app/(manager)/team.tsx
@@ -83,12 +83,7 @@ export default function ManagerTeam() {
     <View style={styles.container}>
       <TopBar />
       <View style={styles.headerRow}>
-         <Text style={styles.headerTitle}>Teams</Text>
-         {requests.length > 0 && (
-           <View style={styles.badge}>
-             <Text style={styles.badgeText}>{requests.length}</Text>
-           </View>
-         )}
+        <Text style={styles.headerTitle}>Teams</Text>
       </View>
       {requests.length > 0 && (
         <View style={styles.reqContainer}>
@@ -199,23 +194,8 @@ export default function ManagerTeam() {
 
 const styles = StyleSheet.create({
   container:{ flex:1, backgroundColor:"#fff" },
-  headerRow:{ paddingHorizontal:12, paddingTop:6, paddingBottom:10, flexDirection:"row", alignItems:"center", justifyContent:"space-between" },
+  headerRow:{ paddingHorizontal:12, paddingTop:6, paddingBottom:10, flexDirection:"row", alignItems:"center" },
   headerTitle:{ fontWeight:"800", fontSize:18, color:"#1F2937" },
-    badge: {
-    minWidth: 22,
-    height: 22,
-    paddingHorizontal: 6,
-    borderRadius: 11,
-    backgroundColor: "#ef4444",
-    alignItems: "center",
-    justifyContent: "center",
-  },
-  badgeText: {
-    color: "#fff",
-    fontWeight: "700",
-    fontSize: 12,
-    lineHeight: 14,
-  },
   reqContainer:{ paddingHorizontal:12, paddingBottom:12 },
   reqRow:{ flexDirection:"row", alignItems:"center", marginBottom:8 },
   reqAvatar:{ width:40, height:40, borderRadius:20, marginRight:12, backgroundColor:"#f1f5f9" },


### PR DESCRIPTION
## Summary
- Only show connection request counts on tab bar badges
- Clean up team pages by removing top-right request badges

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68bda707ff74832099786f75eaefd843