### PR TITLE
Disallow connection requests to clients

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -1334,10 +1334,14 @@ app.post("/connections/request", auth, async (req, res) => {
   const sender = await db
     .prepare("SELECT role FROM users WHERE id = ?")
     .get(req.user.sub);
+  if (sender.role === "client" || receiver.role === "client")
+    return res
+      .status(400)
+      .json({ error: "Connection requests cannot involve clients" });
   if (sender.role === receiver.role)
     return res
       .status(400)
-      .json({ error: "Connections only between labourers and managers" });
+      .json({ error: "Connections only allowed between labourers and managers" });
   const existing = await db
     .prepare("SELECT 1 FROM connections WHERE user_id = ? AND connection_id = ?")
     .get(req.user.sub, receiver.id);


### PR DESCRIPTION
## Summary
- Prevent connection requests from or to users with the `client` role
- Keep connections limited to labourer–manager pairs

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68bda9d36a0c8320b93e953f220c7b08