### PR TITLE
Disallow client connection requests and allow same-role connections

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -1334,10 +1334,10 @@ app.post("/connections/request", auth, async (req, res) => {
   const sender = await db
     .prepare("SELECT role FROM users WHERE id = ?")
     .get(req.user.sub);
-  if (sender.role === receiver.role)
+  if (sender.role === "client" || receiver.role === "client")
     return res
       .status(400)
-      .json({ error: "Connections only between labourers and managers" });
+      .json({ error: "Connection requests cannot involve clients" });
   const existing = await db
     .prepare("SELECT 1 FROM connections WHERE user_id = ? AND connection_id = ?")
     .get(req.user.sub, receiver.id);


### PR DESCRIPTION
## Summary
- Reject connection requests when sender or receiver is a client
- Permit connections between users of the same role (manager-manager, labourer-labourer)

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68bda9d36a0c8320b93e953f220c7b08