### PR TITLE
Restore job profile modal flow when opened from jobs

### DIFF
--- a/mobile/app/(labourer)/(profile)/_layout.tsx
+++ b/mobile/app/(labourer)/(profile)/_layout.tsx
@@ -31,6 +31,14 @@ export default function LabourerProfileStack() {
           gestureEnabled: false,
         }}
       />
+      <Stack.Screen
+        name="profileDetails"
+        options={{
+          headerShown: false,
+          presentation: "modal",
+          animation: "slide_from_bottom",
+        }}
+      />
     </Stack>
   );
 }

--- a/mobile/app/(labourer)/(profile)/profileDetails.tsx
+++ b/mobile/app/(labourer)/(profile)/profileDetails.tsx
@@ -107,6 +107,15 @@ export default function LabourerProfileDetails() {
     if (!isOwn) setEditing(false);
   }, [isOwn, viewUserId]);
 
+  useEffect(() => {
+    return () => {
+      if (from !== "chat" && backJobId) {
+        const dest = from === "jobs" ? "/(labourer)/jobs" : "/(labourer)/map";
+        router.replace({ pathname: dest, params: { jobId: String(backJobId) } });
+      }
+    };
+  }, [from, backJobId]);
+
   const save = () => {
     if (!user || !isOwn) return;
     updateProfile(
@@ -193,20 +202,12 @@ export default function LabourerProfileDetails() {
         <View style={{ flex: 1 }}>
           {/* FIXED Top bar (outside the ScrollView) */}
           <View style={[styles.topBar, { paddingTop: insets.top + 6 }]}>
-            <Pressable
-              onPress={() => {
-                if (from === "chat") {
-                  router.back();
-                } else if (backJobId) {
-                  const dest = from === "jobs" ? "/(labourer)/jobs" : "/(labourer)/map";
-                  router.replace({ pathname: dest, params: { jobId: String(backJobId) } });
-                } else {
-                  router.back();
-                }
-              }}
-              hitSlop={12}
-            >
-              <Ionicons name="chevron-back" size={24} color="#111" />
+            <Pressable onPress={() => router.back()} hitSlop={12}>
+              <Ionicons
+                name={from === "chat" ? "chevron-back" : "chevron-down"}
+                size={24}
+                color="#111"
+              />
             </Pressable>
 
             <Text style={styles.topTitle}>Profile</Text>


### PR DESCRIPTION
## Summary
- Show profile details as a modal when opened from a job
- Reopen the job after closing a profile viewed from jobs or map
- Use a down-chevron when viewing profile from jobs, keep back arrow for chats

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68bdb0b67a408320a23d57942f28948d