### PR TITLE
Restore profile modal when opened from jobs

### DIFF
--- a/mobile/app/(labourer)/(profile)/profileDetails.tsx
+++ b/mobile/app/(labourer)/(profile)/profileDetails.tsx
@@ -182,13 +182,7 @@ export default function LabourerProfileDetails() {
 
   return (
     <>
-      <Stack.Screen
-        options={{
-          headerShown: false,
-          presentation: isJobContext ? "modal" : "card",
-          animation: isJobContext ? "slide_from_bottom" : "slide_from_right",
-        }}
-      />
+      <Stack.Screen options={{ headerShown: false }} />
       <KeyboardAvoidingView
         style={{ flex: 1, backgroundColor: "#fff" }}
         behavior={Platform.OS === "ios" ? "padding" : undefined}

--- a/mobile/app/(labourer)/(profile)/profileDetails.tsx
+++ b/mobile/app/(labourer)/(profile)/profileDetails.tsx
@@ -33,14 +33,12 @@ export default function LabourerProfileDetails() {
   const viewUserId = params.userId
     ? parseInt(Array.isArray(params.userId) ? params.userId[0] : params.userId, 10)
     : authUserId;
-  const backJobId = params.jobId
-    ? Array.isArray(params.jobId) ? params.jobId[0] : params.jobId
-    : undefined;
   const from = params.from
     ? Array.isArray(params.from)
       ? params.from[0]
       : params.from
     : undefined;
+  const isJobContext = from === "jobs" || from === "map";
   const viewRole = (params.role
     ? Array.isArray(params.role)
       ? params.role[0]
@@ -184,7 +182,13 @@ export default function LabourerProfileDetails() {
 
   return (
     <>
-      <Stack.Screen options={{ headerShown: false }} />
+      <Stack.Screen
+        options={{
+          headerShown: false,
+          presentation: isJobContext ? "modal" : "card",
+          animation: isJobContext ? "slide_from_bottom" : "slide_from_right",
+        }}
+      />
       <KeyboardAvoidingView
         style={{ flex: 1, backgroundColor: "#fff" }}
         behavior={Platform.OS === "ios" ? "padding" : undefined}
@@ -193,20 +197,12 @@ export default function LabourerProfileDetails() {
         <View style={{ flex: 1 }}>
           {/* FIXED Top bar (outside the ScrollView) */}
           <View style={[styles.topBar, { paddingTop: insets.top + 6 }]}>
-            <Pressable
-              onPress={() => {
-                if (from === "chat") {
-                  router.back();
-                } else if (backJobId) {
-                  const dest = from === "jobs" ? "/(labourer)/jobs" : "/(labourer)/map";
-                  router.replace({ pathname: dest, params: { jobId: String(backJobId) } });
-                } else {
-                  router.back();
-                }
-              }}
-              hitSlop={12}
-            >
-              <Ionicons name="chevron-back" size={24} color="#111" />
+            <Pressable onPress={() => router.back()} hitSlop={12}>
+              <Ionicons
+                name={isJobContext ? "chevron-down" : "chevron-back"}
+                size={24}
+                color="#111"
+              />
             </Pressable>
 
             <Text style={styles.topTitle}>Profile</Text>

--- a/mobile/app/(labourer)/(profile-modal)/_layout.tsx
+++ b/mobile/app/(labourer)/(profile-modal)/_layout.tsx
@@ -1,0 +1,8 @@
+import { Stack } from "expo-router";
+
+export default function LabourerProfileModalLayout() {
+  return (
+    <Stack screenOptions={{ presentation: "modal", animation: "slide_from_bottom", headerShown: false }} />
+  );
+}
+

--- a/mobile/app/(labourer)/(profile-modal)/profileDetails.tsx
+++ b/mobile/app/(labourer)/(profile-modal)/profileDetails.tsx
@@ -1,0 +1,1 @@
+export { default } from "../(profile)/profileDetails";

--- a/mobile/app/(labourer)/jobs.tsx
+++ b/mobile/app/(labourer)/jobs.tsx
@@ -102,7 +102,7 @@ export default function Jobs() {
       const { userId, jobId } = pendingProfile;
       setPendingProfile(null);
       router.push({
-        pathname: "/(labourer)/(profile)/profileDetails",
+        pathname: "/(labourer)/(profile-modal)/profileDetails",
         params: { userId: String(userId), jobId: String(jobId), from: "jobs" },
       });
     }

--- a/mobile/app/(labourer)/jobs.tsx
+++ b/mobile/app/(labourer)/jobs.tsx
@@ -18,6 +18,7 @@ import { useAuth } from "@src/store/useAuth";
 import { useNotifications } from "@src/store/useNotifications";
 import { Ionicons } from "@expo/vector-icons";
 import { router, useLocalSearchParams } from "expo-router";
+import { useFocusEffect } from "@react-navigation/native";
 import { useProfile } from "@src/store/useProfile";
 import { useAppliedJobs } from "@src/store/useAppliedJobs";
 
@@ -150,6 +151,20 @@ export default function Jobs() {
       }
     }
   }, [jobParam, items]);
+
+  useFocusEffect(
+    useCallback(() => {
+      const jp = Array.isArray(jobParam) ? jobParam[0] : jobParam;
+      const id = jp ? parseInt(jp, 10) : NaN;
+      if (!isNaN(id)) {
+        const job = items.find((j) => j.id === id);
+        if (job) {
+          setSelected(job);
+          setOpen(true);
+        }
+      }
+    }, [jobParam, items])
+  );
 
   const completedJobs = useMemo(() => items.filter((j) => j.status === "completed"), [items]);
 
@@ -419,7 +434,6 @@ export default function Jobs() {
                   disabled={selected.ownerId == null}
                   onPress={() => {
                     if (selected.ownerId == null) return;
-                    router.setParams({ jobId: undefined });
                     setPendingProfile({ userId: selected.ownerId, jobId: selected.id });
                     setOpen(false);
                   }}

--- a/mobile/app/(labourer)/map.tsx
+++ b/mobile/app/(labourer)/map.tsx
@@ -243,6 +243,17 @@ export default function LabourerMap() {
     }
   }, [jobParam, jobs, showJob]);
 
+  useFocusEffect(
+    useCallback(() => {
+      const jp = Array.isArray(jobParam) ? jobParam[0] : jobParam;
+      const id = jp ? parseInt(jp, 10) : NaN;
+      if (!isNaN(id) && jobs.length) {
+        showJob(id);
+        setOpen(true);
+      }
+    }, [jobParam, jobs, showJob])
+  );
+
   const load = async () => {
     const [locs, allJobs] = await Promise.all([listJobLocations(), listJobs()]);
     setMarkers(locs as MarkerLite[]);
@@ -454,7 +465,6 @@ export default function LabourerMap() {
                   disabled={selectedJob.ownerId == null}
                   onPress={() => {
                     if (selectedJob.ownerId == null) return;
-                    router.setParams({ jobId: undefined });
                     setPendingProfile({ userId: selectedJob.ownerId, jobId: selectedJob.id });
                     setOpen(false);
                   }}

--- a/mobile/app/(labourer)/map.tsx
+++ b/mobile/app/(labourer)/map.tsx
@@ -95,7 +95,7 @@ export default function LabourerMap() {
       const { userId, jobId } = pendingProfile;
       setPendingProfile(null);
       router.push({
-        pathname: "/(labourer)/(profile)/profileDetails",
+        pathname: "/(labourer)/(profile-modal)/profileDetails",
         params: { userId: String(userId), jobId: String(jobId), from: "map" },
       });
     }


### PR DESCRIPTION
## Summary
- Reopen job details after dismissing a profile viewed from a job
- Use modal presentation with downward chevron for job-based profile views while keeping chat profiles unchanged

## Testing
- `npm test` (fails: Missing script)
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68bdb28ff5d0832088401aa6db5a0ba8