### PR TITLE
Hide connections button on other users' profiles

### DIFF
--- a/mobile/app/(labourer)/(profile)/profileDetails.tsx
+++ b/mobile/app/(labourer)/(profile)/profileDetails.tsx
@@ -266,18 +266,20 @@ export default function LabourerProfileDetails() {
                 )}
               </Pressable>
             </View>
-            <Pressable
-              onPress={() => router.push("/(labourer)/(profile)/connections")}
-              style={({ pressed }) => [
-                styles.connectionsButton,
-                pressed && { opacity: 0.8 },
-              ]}
-              accessibilityRole="button"
-              accessibilityLabel="Connections"
-            >
-              <Ionicons name="people" size={16} color="#111827" />
-              <Text style={styles.connectionsText}>Connections</Text>
-            </Pressable>
+            {isOwn && (
+              <Pressable
+                onPress={() => router.push("/(labourer)/(profile)/connections")}
+                style={({ pressed }) => [
+                  styles.connectionsButton,
+                  pressed && { opacity: 0.8 },
+                ]}
+                accessibilityRole="button"
+                accessibilityLabel="Connections"
+              >
+                <Ionicons name="people" size={16} color="#111827" />
+                <Text style={styles.connectionsText}>Connections</Text>
+              </Pressable>
+            )}
           </View>
 
           {/* Identity */}


### PR DESCRIPTION
## Summary
- Hide connections link when viewing another user's profile

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68bde8ddb20483208078cbf8ffa42fc3