### PR TITLE
feat: open connection profile

### DIFF
--- a/mobile/app/(labourer)/(profile)/connections.tsx
+++ b/mobile/app/(labourer)/(profile)/connections.tsx
@@ -9,7 +9,7 @@ import {
   Alert,
   FlatList,
 } from "react-native";
-import { Stack } from "expo-router";
+import { Stack, router } from "expo-router";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
 import { Ionicons } from "@expo/vector-icons";
 import {
@@ -19,9 +19,11 @@ import {
   type ConnectionUser,
 } from "@src/lib/api";
 import { Swipeable } from "react-native-gesture-handler";
+import { useAuth } from "@src/store/useAuth";
 
 export default function Connections() {
   const insets = useSafeAreaInsets();
+  const { user } = useAuth();
   const [connections, setConnections] = useState<ConnectionUser[]>([]);
   const [email, setEmail] = useState("");
 
@@ -88,6 +90,10 @@ export default function Connections() {
         renderItem={({ item }) => {
           const thumb =
             item.avatarUri || "https://via.placeholder.com/96x96?text=User";
+          const profilePath =
+            user?.role === "manager"
+              ? "/(manager)/chats/profileDetails"
+              : "/(labourer)/(profile)/profileDetails";
           return (
             <Swipeable
               renderRightActions={() => (
@@ -100,10 +106,21 @@ export default function Connections() {
                 </Pressable>
               )}
             >
-              <View style={styles.row}>
+              <Pressable
+                style={styles.row}
+                onPress={() =>
+                  router.push({
+                    pathname: profilePath,
+                    params: {
+                      userId: String(item.id),
+                      role: item.role,
+                    },
+                  })
+                }
+              >
                 <Image source={{ uri: thumb }} style={styles.avatar} />
                 <Text style={styles.name}>{item.username}</Text>
-              </View>
+              </Pressable>
             </Swipeable>
           );
         }}

--- a/mobile/app/(labourer)/(profile)/connections.tsx
+++ b/mobile/app/(labourer)/(profile)/connections.tsx
@@ -73,20 +73,24 @@ export default function Connections() {
           { paddingBottom: insets.bottom + 24 },
         ]}
         ListHeaderComponent={
-          <View style={styles.searchRow}>
-            <TextInput
-              value={email}
-              onChangeText={setEmail}
-              placeholder="Search by email"
-              style={styles.searchInput}
-              autoCapitalize="none"
-              keyboardType="email-address"
-            />
-            <Pressable style={styles.searchBtn} onPress={handleInvite}>
-              <Ionicons name="send" size={20} color="#fff" />
-            </Pressable>
+          <View style={styles.searchHeader}>
+            <View style={styles.searchRow}>
+              <TextInput
+                value={email}
+                onChangeText={setEmail}
+                placeholder="Search by email"
+                placeholderTextColor="#6B7280"
+                style={styles.searchInput}
+                autoCapitalize="none"
+                keyboardType="email-address"
+              />
+              <Pressable style={styles.searchBtn} onPress={handleInvite}>
+                <Ionicons name="send" size={20} color="#fff" />
+              </Pressable>
+            </View>
           </View>
         }
+        stickyHeaderIndices={[0]}
         renderItem={({ item }) => {
           const thumb =
             item.avatarUri || "https://via.placeholder.com/96x96?text=User";
@@ -137,10 +141,13 @@ const styles = StyleSheet.create({
     backgroundColor: "#fff",
     padding: 16,
   },
+  searchHeader: {
+    backgroundColor: "#fff",
+    paddingBottom: 16,
+  },
   searchRow: {
     flexDirection: "row",
     alignItems: "center",
-    marginBottom: 16,
   },
   searchInput: {
     flex: 1,


### PR DESCRIPTION
## Summary
- allow navigating to connection profiles by tapping tiles

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68bdeab7bc5c83208bbf8c1d80609fa3