### PR TITLE
fix: reset profile navigation from job or map

### DIFF
--- a/mobile/app/(labourer)/jobs.tsx
+++ b/mobile/app/(labourer)/jobs.tsx
@@ -100,7 +100,7 @@ export default function Jobs() {
     if (!open && pendingProfile) {
       const { userId, jobId } = pendingProfile;
       setPendingProfile(null);
-      router.push({
+      router.replace({
         pathname: "/(labourer)/(profile)/profileDetails",
         params: { userId: String(userId), jobId: String(jobId), from: "jobs" },
       });

--- a/mobile/app/(labourer)/map.tsx
+++ b/mobile/app/(labourer)/map.tsx
@@ -94,7 +94,7 @@ export default function LabourerMap() {
     if (!open && pendingProfile) {
       const { userId, jobId } = pendingProfile;
       setPendingProfile(null);
-      router.push({
+      router.replace({
         pathname: "/(labourer)/(profile)/profileDetails",
         params: { userId: String(userId), jobId: String(jobId), from: "map" },
       });


### PR DESCRIPTION
## Summary
- prevent residual profile stack when viewing profile from a job or map

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68bdf1323a9c8320bd93bd7b983f85c3