### PR TITLE
refactor(server): centralize avatar url handling

### DIFF
--- a/server/utils.js
+++ b/server/utils.js
@@ -1,0 +1,40 @@
+const { BlobSASPermissions, generateBlobSASQueryParameters } = require("@azure/storage-blob");
+
+const blobNameFromUrl = (url) => {
+  try {
+    const u = new URL(url);
+    if (u.protocol !== "http:" && u.protocol !== "https:") return null;
+    return u.pathname.split("/").pop();
+  } catch {
+    return null;
+  }
+};
+
+const sasUrl = (container, blobName, blobService) => {
+  const expiresOn = new Date(Date.now() + 365 * 24 * 60 * 60 * 1000);
+  const sas = generateBlobSASQueryParameters(
+    {
+      containerName: container.containerName,
+      blobName,
+      permissions: BlobSASPermissions.parse("r"),
+      expiresOn,
+    },
+    blobService.credential
+  ).toString();
+  return `${container.getBlockBlobClient(blobName).url}?${sas}`;
+};
+
+const avatarUrlFromData = (data, container, blobService) => {
+  try {
+    const { avatarUri } = JSON.parse(data || "{}");
+    if (!avatarUri) return null;
+    const name = blobNameFromUrl(avatarUri);
+    return name && container && blobService
+      ? sasUrl(container, name, blobService)
+      : avatarUri;
+  } catch {
+    return null;
+  }
+};
+
+module.exports = { blobNameFromUrl, sasUrl, avatarUrlFromData };


### PR DESCRIPTION
## Summary
- add shared utility to extract blob names, sign SAS URLs, and parse avatar data
- refactor worker and connection endpoints to reuse avatar utilities and drop duplicated JSON parsing

## Testing
- `npm test` (fails: Missing script)
- `cd server && npm test` (fails: Missing script)


------
https://chatgpt.com/codex/tasks/task_e_68bdf799276c8320939448dac55997d6