### PR TITLE
Preload images before navigation renders

### DIFF
--- a/mobile/app/_layout.tsx
+++ b/mobile/app/_layout.tsx
@@ -13,8 +13,8 @@ export default function RootLayout() {
   useEffect(() => {
     async function loadAssets() {
       await Asset.loadAsync([
-        require("../../assets/images/login.png"),
-        require("../../assets/images/graphic.png"),
+        require("../assets/images/login.png"),
+        require("../assets/images/graphic.png"),
       ]);
       setAssetsLoaded(true);
     }

--- a/mobile/app/_layout.tsx
+++ b/mobile/app/_layout.tsx
@@ -1,7 +1,31 @@
 import { Stack } from "expo-router";
 import { GestureHandlerRootView } from "react-native-gesture-handler";
+import { useEffect, useState } from "react";
+import { Asset } from "expo-asset";
+import { useFonts } from "expo-font";
 
 export default function RootLayout() {
+  const [assetsLoaded, setAssetsLoaded] = useState(false);
+  const [fontsLoaded] = useFonts({
+    SpaceMono: require("../assets/fonts/SpaceMono-Regular.ttf"),
+  });
+
+  useEffect(() => {
+    async function loadAssets() {
+      await Asset.loadAsync([
+        require("../../assets/images/login.png"),
+        require("../../assets/images/graphic.png"),
+      ]);
+      setAssetsLoaded(true);
+    }
+
+    loadAssets();
+  }, []);
+
+  if (!assetsLoaded || !fontsLoaded) {
+    return null;
+  }
+
   return (
     <GestureHandlerRootView style={{ flex: 1 }}>
       <Stack screenOptions={{ headerShown: false }}>


### PR DESCRIPTION
## Summary
- preload login and graphic images before the navigation stack mounts
- wait for fonts and assets to load before rendering the app

## Testing
- `npm test` (fails: Missing script "test")
- `cd mobile && npm test` (fails: Missing script "test")

------
https://chatgpt.com/codex/tasks/task_e_68be0a99a0388320990a2f0fcdf5a191