### PR TITLE
fix: clean back navigation from profile

### DIFF
--- a/mobile/app/(labourer)/(profile)/profileDetails.tsx
+++ b/mobile/app/(labourer)/(profile)/profileDetails.tsx
@@ -26,21 +26,11 @@ export default function LabourerProfileDetails() {
   const authUserId = user?.id ?? 0;
   const params = useLocalSearchParams<{
     userId?: string;
-    jobId?: string;
-    from?: string;
     role?: string;
   }>();
   const viewUserId = params.userId
     ? parseInt(Array.isArray(params.userId) ? params.userId[0] : params.userId, 10)
     : authUserId;
-  const backJobId = params.jobId
-    ? Array.isArray(params.jobId) ? params.jobId[0] : params.jobId
-    : undefined;
-  const from = params.from
-    ? Array.isArray(params.from)
-      ? params.from[0]
-      : params.from
-    : undefined;
   const viewRole = (params.role
     ? Array.isArray(params.role)
       ? params.role[0]
@@ -193,19 +183,7 @@ export default function LabourerProfileDetails() {
         <View style={{ flex: 1 }}>
           {/* FIXED Top bar (outside the ScrollView) */}
           <View style={[styles.topBar, { paddingTop: insets.top + 6 }]}>
-            <Pressable
-              onPress={() => {
-                if (from === "chat") {
-                  router.back();
-                } else if (backJobId) {
-                  const dest = from === "jobs" ? "/(labourer)/jobs" : "/(labourer)/map";
-                  router.replace({ pathname: dest, params: { jobId: String(backJobId) } });
-                } else {
-                  router.back();
-                }
-              }}
-              hitSlop={12}
-            >
+            <Pressable onPress={() => router.back()} hitSlop={12}>
               <Ionicons name="chevron-back" size={24} color="#111" />
             </Pressable>
 

--- a/mobile/app/(labourer)/jobs.tsx
+++ b/mobile/app/(labourer)/jobs.tsx
@@ -87,7 +87,7 @@ export default function Jobs() {
 
   const [selected, setSelected] = useState<Job | null>(null);
   const [open, setOpen] = useState(false);
-  const [pendingProfile, setPendingProfile] = useState<{ userId: number; jobId: number } | null>(null);
+  const [pendingProfile, setPendingProfile] = useState<number | null>(null);
 
   // Applied state for the selected job
   const [appliedChatId, setAppliedChatId] = useState<number | null>(null);
@@ -97,12 +97,12 @@ export default function Jobs() {
   const { applied: appliedJobs, setApplied, setMany } = useAppliedJobs();
 
   useEffect(() => {
-    if (!open && pendingProfile) {
-      const { userId, jobId } = pendingProfile;
+    if (!open && pendingProfile != null) {
+      const userId = pendingProfile;
       setPendingProfile(null);
-      router.replace({
+      router.push({
         pathname: "/(labourer)/(profile)/profileDetails",
-        params: { userId: String(userId), jobId: String(jobId), from: "jobs" },
+        params: { userId: String(userId) },
       });
     }
   }, [open, pendingProfile]);
@@ -420,7 +420,7 @@ export default function Jobs() {
                   onPress={() => {
                     if (selected.ownerId == null) return;
                     router.setParams({ jobId: undefined });
-                    setPendingProfile({ userId: selected.ownerId, jobId: selected.id });
+                    setPendingProfile(selected.ownerId);
                     setOpen(false);
                   }}
                   style={{ marginRight: 8 }}

--- a/mobile/app/(labourer)/map.tsx
+++ b/mobile/app/(labourer)/map.tsx
@@ -79,7 +79,7 @@ export default function LabourerMap() {
   const [prevJob, setPrevJob] = useState<Job | null>(null);
 
   const [open, setOpen] = useState(false); // job details modal
-  const [pendingProfile, setPendingProfile] = useState<{ userId: number; jobId: number } | null>(null);
+  const [pendingProfile, setPendingProfile] = useState<number | null>(null);
   const [appliedChatId, setAppliedChatId] = useState<number | null>(null);
   const [appliedStatus, setAppliedStatus] = useState<"pending" | "accepted" | "declined" | null>(null);
   const [checkingApplied, setCheckingApplied] = useState(false);
@@ -91,12 +91,12 @@ export default function LabourerMap() {
   const [showPay, setShowPay] = useState(false);
 
   useEffect(() => {
-    if (!open && pendingProfile) {
-      const { userId, jobId } = pendingProfile;
+    if (!open && pendingProfile != null) {
+      const userId = pendingProfile;
       setPendingProfile(null);
-      router.replace({
+      router.push({
         pathname: "/(labourer)/(profile)/profileDetails",
-        params: { userId: String(userId), jobId: String(jobId), from: "map" },
+        params: { userId: String(userId) },
       });
     }
   }, [open, pendingProfile]);
@@ -455,7 +455,7 @@ export default function LabourerMap() {
                   onPress={() => {
                     if (selectedJob.ownerId == null) return;
                     router.setParams({ jobId: undefined });
-                    setPendingProfile({ userId: selectedJob.ownerId, jobId: selectedJob.id });
+                    setPendingProfile(selectedJob.ownerId);
                     setOpen(false);
                   }}
                   style={{ marginRight: 8 }}


### PR DESCRIPTION
## Summary
- simplify profile view params and always use router.back for exiting
- use `router.push` for viewing profiles from jobs and map

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68be185649c8832092bc404e0d34feac