### PR TITLE
chore: remove unused mongoose dependency

### DIFF
--- a/server/package.json
+++ b/server/package.json
@@ -15,7 +15,6 @@
     "braintree": "^3.33.1",
     "openai": "^4.0.0",
     "jsonwebtoken": "^9.0.2",
-    "mongoose": "^8.17.1",
     "multer": "^2.0.2",
     "socket.io": "^4.8.1"
   }


### PR DESCRIPTION
## Summary
- remove unused mongoose package from server dependencies

## Testing
- `npm test` (fails: Missing script: "test")

------
https://chatgpt.com/codex/tasks/task_e_68c55d44612083208ba22f2812ae44c1