### PR TITLE
chore: remove unused mongoose dependency

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -261,7 +261,7 @@ app.post("/auth/register", async (req, res) => {
   const { email, username, password, role = "labourer" } = req.body || {};
   if (!email || !username || !password) return res.status(400).json({ error: "Missing fields" });
   try {
-    const hash = bcrypt.hashSync(password, 8);
+    const hash = await bcrypt.hash(password, 8);
     const id = (
       await db
         .prepare(
@@ -286,7 +286,7 @@ app.post("/auth/login", async (req, res) => {
     .prepare("SELECT * FROM users WHERE email = ?")
     .get(email || "");
   if (!user) return res.status(401).json({ error: "Invalid credentials" });
-  const ok = bcrypt.compareSync(password || "", user.password_hash);
+  const ok = await bcrypt.compare(password || "", user.password_hash);
   if (!ok) return res.status(401).json({ error: "Invalid credentials" });
   const safe = {
     id: user.id,

--- a/server/package.json
+++ b/server/package.json
@@ -15,7 +15,6 @@
     "braintree": "^3.33.1",
     "openai": "^4.0.0",
     "jsonwebtoken": "^9.0.2",
-    "mongoose": "^8.17.1",
     "multer": "^2.0.2",
     "socket.io": "^4.8.1"
   }


### PR DESCRIPTION
## Summary
- remove unused mongoose package from server dependencies
- switch password hashing to async bcrypt operations to avoid blocking the event loop

## Testing
- `npm test` (fails: Missing script: "test")
- `(cd server && npm test)` (fails: Missing script: "test")

------
https://chatgpt.com/codex/tasks/task_e_68c55d44612083208ba22f2812ae44c1