### PR TITLE
Show project workers on manager job page

### DIFF
--- a/mobile/app/(manager)/projects.tsx
+++ b/mobile/app/(manager)/projects.tsx
@@ -17,7 +17,15 @@ import {
   ActionSheetIOS,
 } from "react-native";
 import TopBar from "@src/components/TopBar";
-import { listManagerJobs, createJob, updateJob, deleteJob, type CreateJobInput, type Job } from "@src/lib/api";
+import {
+  listManagerJobs,
+  createJob,
+  updateJob,
+  deleteJob,
+  listJobWorkers,
+  type CreateJobInput,
+  type Job,
+} from "@src/lib/api";
 import { useAuth } from "@src/store/useAuth";
 import DateRangeSheet from "@src/components/DateRangeSheet";
 import { Colors } from "@src/theme/tokens";
@@ -37,6 +45,16 @@ function formatPay(pay?: string) {
   return t;
 }
 
+function initials(name: string) {
+  return name
+    .split(" ")
+    .map((n) => n[0])
+    .filter(Boolean)
+    .join("")
+    .slice(0, 2)
+    .toUpperCase();
+}
+
 const DEFAULT_REGION: Region = {
   latitude: 51.5074,
   longitude: -0.1278,
@@ -52,6 +70,7 @@ export default function ManagerProjects() {
   const [open, setOpen] = useState(false);
   const [detailsOpen, setDetailsOpen] = useState(false);
   const [selected, setSelected] = useState<Job | null>(null);
+  const [workers, setWorkers] = useState<{ id: number; name: string; avatarUri?: string }[]>([]);
 
   // form state
   const [title, setTitle] = useState("");
@@ -89,6 +108,14 @@ export default function ManagerProjects() {
   useEffect(() => {
     refresh();
   }, [refresh]);
+
+  useEffect(() => {
+    if (detailsOpen && selected?.id) {
+      listJobWorkers(selected.id).then(setWorkers);
+    } else {
+      setWorkers([]);
+    }
+  }, [detailsOpen, selected?.id]);
 
   const today = new Date().toISOString().slice(0, 10);
   const upcoming: Job[] = [];
@@ -744,6 +771,39 @@ export default function ManagerProjects() {
               <View style={{ marginTop: 10 }}>
                 <Text style={{ fontWeight: "700", color: "#1F2937" }}>About this job</Text>
                 <Text style={{ color: "#374151", marginTop: 4 }}>{selected.description}</Text>
+              </View>
+            )}
+
+            {workers.length > 0 && (
+              <View style={{ marginTop: 16 }}>
+                <Text style={{ fontWeight: "700", color: "#1F2937" }}>Workers</Text>
+                <View style={{ flexDirection: "row", gap: 8, marginTop: 8 }}>
+                  {workers.map((w) => (
+                    <View key={w.id} style={{ width: 40, height: 40 }}>
+                      {w.avatarUri ? (
+                        <Image
+                          source={{ uri: w.avatarUri }}
+                          style={{ width: 40, height: 40, borderRadius: 20 }}
+                        />
+                      ) : (
+                        <View
+                          style={{
+                            width: 40,
+                            height: 40,
+                            borderRadius: 20,
+                            backgroundColor: Colors.primary,
+                            alignItems: "center",
+                            justifyContent: "center",
+                          }}
+                        >
+                          <Text style={{ color: "#fff", fontWeight: "700" }}>
+                            {initials(w.name)}
+                          </Text>
+                        </View>
+                      )}
+                    </View>
+                  ))}
+                </View>
               </View>
             )}
           </View>

--- a/mobile/src/lib/api.ts
+++ b/mobile/src/lib/api.ts
@@ -315,9 +315,12 @@ export async function listJobLocations() {
 }
 
 export async function listJobWorkers(jobId: number): Promise<{ id: number; name: string; avatarUri?: string }[]> {
-  if (API_BASE) {
+  const token = useAuth.getState().token;
+  if (API_BASE && token) {
     try {
-      const r = await fetch(`${API_BASE}/jobs/${jobId}/workers`);
+      const r = await fetch(`${API_BASE}/jobs/${jobId}/workers`, {
+        headers: headers(token),
+      });
       if (r.ok) {
         const workers = await r.json();
         return workers.map((w: any) => ({ id: w.id, name: w.username, avatarUri: w.avatarUri }));


### PR DESCRIPTION
## Summary
- track worker join time in `project_workers` and limit job worker API to the job owner
- add authenticated `listJobWorkers` API call
- display a row of worker avatars below "About this job" for managers, with initials fallback

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68c57fe9ab6c8320be7d2e962900a17b